### PR TITLE
Conflict with Slim 3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,6 +29,9 @@
   "require-dev": {
     "phpunit/phpunit": "^5.0"
   },
+  "conflict": {
+    "slim/slim": "^3.0"
+  },
   "autoload": {
     "psr-4": {
       "Slim\\Http\\": "src",


### PR DESCRIPTION
This PR adds the conflict note for composer for `"slim/slim": "^3.0"`. My understanding is that `slim/http` targets upcoming Slim 4 and is not supposed to be used with Slim 3. Furthermore installing `slim/http` into Slim 3 project will break the app with the error below.

```
Call to undefined method Slim\\Http\\Request::createFromEnvironment()
```

There also is some confusion with third party code such as [http-interop/http-factory-slim](https://github.com/http-interop/http-factory-slim) which was meant to be used with Slim 3 but currently wrongly includes `slim/http` instead of `slim/slim`. I am also submitting a PR for that project soonish.


