### PR TITLE
Remove deprecated factory

### DIFF
--- a/src/Request.php
+++ b/src/Request.php
@@ -172,28 +172,6 @@ class Request extends Message implements ServerRequestInterface
         });
     }
 
-    public static function createFromGlobals(array $globals)
-    {
-        $env = new Collection($globals);
-        $method = $env->get('REQUEST_METHOD');
-        $uri = Uri::createFromGlobals($globals);
-        $headers = Headers::createFromGlobals($globals);
-        $cookies = Cookies::parseHeader($headers->get('Cookie', []));
-        $serverParams = $globals;
-        $body = new RequestBody();
-        $uploadedFiles = UploadedFile::createFromGlobals($globals);
-        $request = new static($method, $uri, $headers, $cookies, $serverParams, $body, $uploadedFiles);
-
-        if ($method === 'POST' &&
-            in_array($request->getMediaType(), ['application/x-www-form-urlencoded', 'multipart/form-data'])
-        ) {
-            // parsed body must be $_POST
-            $request = $request->withParsedBody($_POST);
-        }
-
-        return $request;
-    }
-
     /**
      * This method is applied to the cloned object
      * after PHP performs an initial shallow-copy. This

--- a/tests/RequestTest.php
+++ b/tests/RequestTest.php
@@ -94,9 +94,6 @@ class RequestTest extends \PHPUnit_Framework_TestCase
         $this->assertAttributeEquals(null, 'method', $request);
     }
 
-    /**
-     * @covers Slim\Http\Request::createFromGlobals
-     */
     public function testCreateFromEnvironmentWithMultipart()
     {
         $_POST['foo'] = 'bar';


### PR DESCRIPTION
This method was originally used in Slim 3.x to instantiate the Request.

In Slim-Http there's a dedicated FactoryDefault class for that, and `Uri::createFromGlobals(array $globals)` does not even exist anymore.