### PR TITLE
Allow request method to be case sensitive

### DIFF
--- a/src/Request.php
+++ b/src/Request.php
@@ -279,7 +279,6 @@ class Request extends Message implements ServerRequestInterface
             ));
         }
 
-        $method = strtoupper($method);
         if (preg_match("/^[!#$%&'*+.^_`|~0-9a-z-]+$/i", $method) !== 1) {
             throw new InvalidArgumentException(sprintf(
                 'Unsupported HTTP method "%s" provided',

--- a/tests/RequestTest.php
+++ b/tests/RequestTest.php
@@ -69,6 +69,13 @@ class RequestTest extends TestCase
         $this->assertAttributeEquals('PUT', 'method', $request);
     }
 
+    public function testWithMethodCaseSensitive()
+    {
+        $request = $this->requestFactory()->withMethod('pOsT');
+
+        $this->assertAttributeEquals('pOsT', 'method', $request);
+    }
+
     public function testWithAllAllowedCharactersMethod()
     {
         $request = $this->requestFactory()->withMethod("!#$%&'*+.^_`|~09AZ-");


### PR DESCRIPTION
This should fix slimphp/Slim#2169 by removing strtoupper from request method.