### PR TITLE
Fix links in license header to slim-http instead of slim

### DIFF
--- a/src/Body.php
+++ b/src/Body.php
@@ -2,9 +2,9 @@
 /**
  * Slim Framework (https://slimframework.com)
  *
- * @link      https://github.com/slimphp/Slim
+ * @link      https://github.com/slimphp/Slim-Http
  * @copyright Copyright (c) 2011-2017 Josh Lockhart
- * @license   https://github.com/slimphp/Slim/blob/3.x/LICENSE.md (MIT License)
+ * @license   https://github.com/slimphp/Slim-Http/blob/master/LICENSE (MIT License)
  */
 namespace Slim\Http;
 

--- a/src/Collection.php
+++ b/src/Collection.php
@@ -1,10 +1,10 @@
 <?php
 /**
- * Slim Framework (http://slimframework.com)
+ * Slim Framework (https://slimframework.com)
  *
- * @link      https://github.com/slimphp/Slim
+ * @link      https://github.com/slimphp/Slim-Http
  * @copyright Copyright (c) 2011-2017 Josh Lockhart
- * @license   https://github.com/slimphp/Slim/blob/3.x/LICENSE.md (MIT License)
+ * @license   https://github.com/slimphp/Slim-Http/blob/master/LICENSE (MIT License)
  */
 namespace Slim\Http;
 

--- a/src/CollectionInterface.php
+++ b/src/CollectionInterface.php
@@ -1,10 +1,10 @@
 <?php
 /**
- * Slim Framework (http://slimframework.com)
+ * Slim Framework (https://slimframework.com)
  *
- * @link      https://github.com/slimphp/Slim
+ * @link      https://github.com/slimphp/Slim-Http
  * @copyright Copyright (c) 2011-2017 Josh Lockhart
- * @license   https://github.com/slimphp/Slim/blob/3.x/LICENSE.md (MIT License)
+ * @license   https://github.com/slimphp/Slim-Http/blob/master/LICENSE (MIT License)
  */
 namespace Slim\Http;
 

--- a/src/Cookies.php
+++ b/src/Cookies.php
@@ -2,9 +2,9 @@
 /**
  * Slim Framework (https://slimframework.com)
  *
- * @link      https://github.com/slimphp/Slim
+ * @link      https://github.com/slimphp/Slim-Http
  * @copyright Copyright (c) 2011-2017 Josh Lockhart
- * @license   https://github.com/slimphp/Slim/blob/3.x/LICENSE.md (MIT License)
+ * @license   https://github.com/slimphp/Slim-Http/blob/master/LICENSE (MIT License)
  */
 namespace Slim\Http;
 

--- a/src/CookiesInterface.php
+++ b/src/CookiesInterface.php
@@ -1,10 +1,10 @@
 <?php
 /**
- * Slim Framework (http://slimframework.com)
+ * Slim Framework (https://slimframework.com)
  *
- * @link      https://github.com/slimphp/Slim
+ * @link      https://github.com/slimphp/Slim-Http
  * @copyright Copyright (c) 2011-2017 Josh Lockhart
- * @license   https://github.com/slimphp/Slim/blob/3.x/LICENSE.md (MIT License)
+ * @license   https://github.com/slimphp/Slim-Http/blob/master/LICENSE (MIT License)
  */
 namespace Slim\Http;
 

--- a/src/Environment.php
+++ b/src/Environment.php
@@ -1,10 +1,10 @@
 <?php
 /**
- * Slim Framework (http://slimframework.com)
+ * Slim Framework (https://slimframework.com)
  *
- * @link      https://github.com/slimphp/Slim
+ * @link      https://github.com/slimphp/Slim-Http
  * @copyright Copyright (c) 2011-2017 Josh Lockhart
- * @license   https://github.com/slimphp/Slim/blob/3.x/LICENSE.md (MIT License)
+ * @license   https://github.com/slimphp/Slim-Http/blob/master/LICENSE (MIT License)
  */
 namespace Slim\Http;
 

--- a/src/Headers.php
+++ b/src/Headers.php
@@ -2,9 +2,9 @@
 /**
  * Slim Framework (https://slimframework.com)
  *
- * @link      https://github.com/slimphp/Slim
+ * @link      https://github.com/slimphp/Slim-Http
  * @copyright Copyright (c) 2011-2017 Josh Lockhart
- * @license   https://github.com/slimphp/Slim/blob/3.x/LICENSE.md (MIT License)
+ * @license   https://github.com/slimphp/Slim-Http/blob/master/LICENSE (MIT License)
  */
 namespace Slim\Http;
 

--- a/src/HeadersInterface.php
+++ b/src/HeadersInterface.php
@@ -1,10 +1,10 @@
 <?php
 /**
- * Slim Framework (http://slimframework.com)
+ * Slim Framework (https://slimframework.com)
  *
- * @link      https://github.com/slimphp/Slim
+ * @link      https://github.com/slimphp/Slim-Http
  * @copyright Copyright (c) 2011-2017 Josh Lockhart
- * @license   https://github.com/slimphp/Slim/blob/3.x/LICENSE.md (MIT License)
+ * @license   https://github.com/slimphp/Slim-Http/blob/master/LICENSE (MIT License)
  */
 namespace Slim\Http;
 

--- a/src/Message.php
+++ b/src/Message.php
@@ -2,9 +2,9 @@
 /**
  * Slim Framework (https://slimframework.com)
  *
- * @link      https://github.com/slimphp/Slim
+ * @link      https://github.com/slimphp/Slim-Http
  * @copyright Copyright (c) 2011-2017 Josh Lockhart
- * @license   https://github.com/slimphp/Slim/blob/3.x/LICENSE.md (MIT License)
+ * @license   https://github.com/slimphp/Slim-Http/blob/master/LICENSE (MIT License)
  */
 namespace Slim\Http;
 

--- a/src/Request.php
+++ b/src/Request.php
@@ -2,9 +2,9 @@
 /**
  * Slim Framework (https://slimframework.com)
  *
- * @link      https://github.com/slimphp/Slim
+ * @link      https://github.com/slimphp/Slim-Http
  * @copyright Copyright (c) 2011-2017 Josh Lockhart
- * @license   https://github.com/slimphp/Slim/blob/3.x/LICENSE.md (MIT License)
+ * @license   https://github.com/slimphp/Slim-Http/blob/master/LICENSE (MIT License)
  */
 namespace Slim\Http;
 

--- a/src/RequestBody.php
+++ b/src/RequestBody.php
@@ -2,9 +2,9 @@
 /**
  * Slim Framework (https://slimframework.com)
  *
- * @link      https://github.com/slimphp/Slim
+ * @link      https://github.com/slimphp/Slim-Http
  * @copyright Copyright (c) 2011-2017 Josh Lockhart
- * @license   https://github.com/slimphp/Slim/blob/3.x/LICENSE.md (MIT License)
+ * @license   https://github.com/slimphp/Slim-Http/blob/master/LICENSE (MIT License)
  */
 namespace Slim\Http;
 

--- a/src/Response.php
+++ b/src/Response.php
@@ -2,9 +2,9 @@
 /**
  * Slim Framework (https://slimframework.com)
  *
- * @link      https://github.com/slimphp/Slim
+ * @link      https://github.com/slimphp/Slim-Http
  * @copyright Copyright (c) 2011-2017 Josh Lockhart
- * @license   https://github.com/slimphp/Slim/blob/3.x/LICENSE.md (MIT License)
+ * @license   https://github.com/slimphp/Slim-Http/blob/master/LICENSE (MIT License)
  */
 namespace Slim\Http;
 

--- a/src/Stream.php
+++ b/src/Stream.php
@@ -2,9 +2,9 @@
 /**
  * Slim Framework (https://slimframework.com)
  *
- * @link      https://github.com/slimphp/Slim
+ * @link      https://github.com/slimphp/Slim-Http
  * @copyright Copyright (c) 2011-2017 Josh Lockhart
- * @license   https://github.com/slimphp/Slim/blob/3.x/LICENSE.md (MIT License)
+ * @license   https://github.com/slimphp/Slim-Http/blob/master/LICENSE (MIT License)
  */
 namespace Slim\Http;
 

--- a/src/UploadedFile.php
+++ b/src/UploadedFile.php
@@ -2,9 +2,9 @@
 /**
  * Slim Framework (https://slimframework.com)
  *
- * @link      https://github.com/slimphp/Slim
+ * @link      https://github.com/slimphp/Slim-Http
  * @copyright Copyright (c) 2011-2017 Josh Lockhart
- * @license   https://github.com/slimphp/Slim/blob/3.x/LICENSE.md (MIT License)
+ * @license   https://github.com/slimphp/Slim-Http/blob/master/LICENSE (MIT License)
  */
 namespace Slim\Http;
 

--- a/src/Uri.php
+++ b/src/Uri.php
@@ -2,9 +2,9 @@
 /**
  * Slim Framework (https://slimframework.com)
  *
- * @link      https://github.com/slimphp/Slim
+ * @link      https://github.com/slimphp/Slim-Http
  * @copyright Copyright (c) 2011-2017 Josh Lockhart
- * @license   https://github.com/slimphp/Slim/blob/3.x/LICENSE.md (MIT License)
+ * @license   https://github.com/slimphp/Slim-Http/blob/master/LICENSE (MIT License)
  */
 namespace Slim\Http;
 

--- a/tests/BodyTest.php
+++ b/tests/BodyTest.php
@@ -2,9 +2,9 @@
 /**
  * Slim Framework (https://slimframework.com)
  *
- * @link      https://github.com/slimphp/Slim
+ * @link      https://github.com/slimphp/Slim-Http
  * @copyright Copyright (c) 2011-2017 Josh Lockhart
- * @license   https://github.com/slimphp/Slim/blob/3.x/LICENSE.md (MIT License)
+ * @license   https://github.com/slimphp/Slim-Http/blob/master/LICENSE (MIT License)
  */
 namespace Slim\Tests\Http;
 

--- a/tests/CollectionTest.php
+++ b/tests/CollectionTest.php
@@ -1,10 +1,10 @@
 <?php
 /**
- * Slim Framework (http://slimframework.com)
+ * Slim Framework (https://slimframework.com)
  *
- * @link      https://github.com/slimphp/Slim
+ * @link      https://github.com/slimphp/Slim-Http
  * @copyright Copyright (c) 2011-2017 Josh Lockhart
- * @license   https://github.com/slimphp/Slim/blob/master/LICENSE.md (MIT License)
+ * @license   https://github.com/slimphp/Slim-Http/blob/master/LICENSE (MIT License)
  */
 namespace Slim\Tests;
 

--- a/tests/CookiesTest.php
+++ b/tests/CookiesTest.php
@@ -2,9 +2,9 @@
 /**
  * Slim Framework (https://slimframework.com)
  *
- * @link      https://github.com/slimphp/Slim
+ * @link      https://github.com/slimphp/Slim-Http
  * @copyright Copyright (c) 2011-2017 Josh Lockhart
- * @license   https://github.com/slimphp/Slim/blob/3.x/LICENSE.md (MIT License)
+ * @license   https://github.com/slimphp/Slim-Http/blob/master/LICENSE (MIT License)
  */
 namespace Slim\Tests\Http;
 

--- a/tests/EnvironmentTest.php
+++ b/tests/EnvironmentTest.php
@@ -2,9 +2,9 @@
 /**
  * Slim Framework (https://slimframework.com)
  *
- * @link      https://github.com/slimphp/Slim
+ * @link      https://github.com/slimphp/Slim-Http
  * @copyright Copyright (c) 2011-2017 Josh Lockhart
- * @license   https://github.com/slimphp/Slim/blob/3.x/LICENSE.md (MIT License)
+ * @license   https://github.com/slimphp/Slim-Http/blob/master/LICENSE (MIT License)
  */
 namespace Slim\Tests\Http;
 

--- a/tests/HeadersTest.php
+++ b/tests/HeadersTest.php
@@ -2,9 +2,9 @@
 /**
  * Slim Framework (https://slimframework.com)
  *
- * @link      https://github.com/slimphp/Slim
+ * @link      https://github.com/slimphp/Slim-Http
  * @copyright Copyright (c) 2011-2017 Josh Lockhart
- * @license   https://github.com/slimphp/Slim/blob/3.x/LICENSE.md (MIT License)
+ * @license   https://github.com/slimphp/Slim-Http/blob/master/LICENSE (MIT License)
  */
 namespace Slim\Tests\Http;
 

--- a/tests/MessageTest.php
+++ b/tests/MessageTest.php
@@ -2,9 +2,9 @@
 /**
  * Slim Framework (https://slimframework.com)
  *
- * @link      https://github.com/slimphp/Slim
+ * @link      https://github.com/slimphp/Slim-Http
  * @copyright Copyright (c) 2011-2017 Josh Lockhart
- * @license   https://github.com/slimphp/Slim/blob/3.x/LICENSE.md (MIT License)
+ * @license   https://github.com/slimphp/Slim-Http/blob/master/LICENSE (MIT License)
  */
 namespace Slim\Tests\Http;
 

--- a/tests/Mocks/MessageStub.php
+++ b/tests/Mocks/MessageStub.php
@@ -1,10 +1,10 @@
 <?php
 /**
- * Slim Framework (http://slimframework.com)
+ * Slim Framework (https://slimframework.com)
  *
- * @link      https://github.com/slimphp/Slim
+ * @link      https://github.com/slimphp/Slim-Http
  * @copyright Copyright (c) 2011-2017 Josh Lockhart
- * @license   https://github.com/slimphp/Slim/blob/master/LICENSE.md (MIT License)
+ * @license   https://github.com/slimphp/Slim-Http/blob/master/LICENSE (MIT License)
  */
 namespace Slim\Tests\Http\Mocks;
 

--- a/tests/RequestBodyTest.php
+++ b/tests/RequestBodyTest.php
@@ -2,9 +2,9 @@
 /**
  * Slim Framework (https://slimframework.com)
  *
- * @link      https://github.com/slimphp/Slim
+ * @link      https://github.com/slimphp/Slim-Http
  * @copyright Copyright (c) 2011-2017 Josh Lockhart
- * @license   https://github.com/slimphp/Slim/blob/3.x/LICENSE.md (MIT License)
+ * @license   https://github.com/slimphp/Slim-Http/blob/master/LICENSE (MIT License)
  */
 namespace Slim\Tests\Http;
 

--- a/tests/RequestTest.php
+++ b/tests/RequestTest.php
@@ -2,11 +2,10 @@
 /**
  * Slim Framework (https://slimframework.com)
  *
- * @link      https://github.com/slimphp/Slim
+ * @link      https://github.com/slimphp/Slim-Http
  * @copyright Copyright (c) 2011-2017 Josh Lockhart
- * @license   https://github.com/slimphp/Slim/blob/3.x/LICENSE.md (MIT License)
+ * @license   https://github.com/slimphp/Slim-Http/blob/master/LICENSE (MIT License)
  */
-
 namespace Slim\Tests\Http;
 
 use PHPUnit\Framework\TestCase;

--- a/tests/ResponseTest.php
+++ b/tests/ResponseTest.php
@@ -2,9 +2,9 @@
 /**
  * Slim Framework (https://slimframework.com)
  *
- * @link      https://github.com/slimphp/Slim
+ * @link      https://github.com/slimphp/Slim-Http
  * @copyright Copyright (c) 2011-2017 Josh Lockhart
- * @license   https://github.com/slimphp/Slim/blob/3.x/LICENSE.md (MIT License)
+ * @license   https://github.com/slimphp/Slim-Http/blob/master/LICENSE (MIT License)
  */
 namespace Slim\Tests\Http;
 

--- a/tests/StreamTest.php
+++ b/tests/StreamTest.php
@@ -2,9 +2,9 @@
 /**
  * Slim Framework (https://slimframework.com)
  *
- * @link      https://github.com/slimphp/Slim
+ * @link      https://github.com/slimphp/Slim-Http
  * @copyright Copyright (c) 2011-2017 Josh Lockhart
- * @license   https://github.com/slimphp/Slim/blob/3.x/LICENSE.md (MIT License)
+ * @license   https://github.com/slimphp/Slim-Http/blob/master/LICENSE (MIT License)
  */
 namespace Slim\Tests\Http;
 

--- a/tests/UploadedFilesTest.php
+++ b/tests/UploadedFilesTest.php
@@ -2,9 +2,9 @@
 /**
  * Slim Framework (https://slimframework.com)
  *
- * @link      https://github.com/slimphp/Slim
+ * @link      https://github.com/slimphp/Slim-Http
  * @copyright Copyright (c) 2011-2017 Josh Lockhart
- * @license   https://github.com/slimphp/Slim/blob/3.x/LICENSE.md (MIT License)
+ * @license   https://github.com/slimphp/Slim-Http/blob/master/LICENSE (MIT License)
  */
 namespace Slim\Tests\Http;
 

--- a/tests/UriTest.php
+++ b/tests/UriTest.php
@@ -2,9 +2,9 @@
 /**
  * Slim Framework (https://slimframework.com)
  *
- * @link      https://github.com/slimphp/Slim
+ * @link      https://github.com/slimphp/Slim-Http
  * @copyright Copyright (c) 2011-2017 Josh Lockhart
- * @license   https://github.com/slimphp/Slim/blob/3.x/LICENSE.md (MIT License)
+ * @license   https://github.com/slimphp/Slim-Http/blob/master/LICENSE (MIT License)
  */
 namespace Slim\Tests\Http;
 


### PR DESCRIPTION
The links in the license header still points to slim 3, they should point to their own repository.