### PR TITLE
Encode user info

### DIFF
--- a/src/Uri.php
+++ b/src/Uri.php
@@ -353,10 +353,29 @@ class Uri implements UriInterface
     public function withUserInfo($user, $password = null)
     {
         $clone = clone $this;
-        $clone->user = $user;
-        $clone->password = $password ? $password : '';
+        $clone->user = $this->filterUserInfo($user);
+        if ($clone->user) {
+            $clone->password = $password ? $this->filterUserInfo($password) : '';
+        }
 
         return $clone;
+    }
+
+    /**
+     * Filters the user info string.
+     *
+     * @param string $query The raw uri query string.
+     * @return string The percent-encoded query string.
+     */
+    protected function filterUserInfo($query)
+    {
+        return preg_replace_callback(
+            '/(?:[^a-zA-Z0-9_\-\.~!\$&\'\(\)\*\+,;=]+|%(?![A-Fa-f0-9]{2}))/u',
+            function ($match) {
+                return rawurlencode($match[0]);
+            },
+            $query
+        );
     }
 
     /**

--- a/tests/UriTest.php
+++ b/tests/UriTest.php
@@ -114,6 +114,13 @@ class UriTest extends TestCase
         $this->assertEquals('josh:sekrit', $uri->getUserInfo());
     }
 
+    public function testGetUserInfoWithUsernameAndPasswordEncodesCorrectly()
+    {
+        $uri = Uri::createFromString('https://bob%40example.com:pass%3Aword@example.com:443/foo/bar?abc=123#section3');
+
+        $this->assertEquals('bob%40example.com:pass%3Aword', $uri->getUserInfo());
+    }
+
     public function testGetUserInfoWithUsername()
     {
         $uri = Uri::createFromString('http://josh@example.com/foo/bar?abc=123#section3');
@@ -134,6 +141,14 @@ class UriTest extends TestCase
 
         $this->assertAttributeEquals('bob', 'user', $uri);
         $this->assertAttributeEquals('pass', 'password', $uri);
+    }
+
+    public function testWithUserInfoEncodesCorrectly()
+    {
+        $uri = $this->uriFactory()->withUserInfo('bob@example.com', 'pass:word');
+
+        $this->assertAttributeEquals('bob%40example.com', 'user', $uri);
+        $this->assertAttributeEquals('pass%3Aword', 'password', $uri);
     }
 
     public function testWithUserInfoRemovesPassword()


### PR DESCRIPTION
If the username or password includes an `@` or `:` or other reserved
characters, they need to be encoded.

Fixes #34
Forward ports https://github.com/slimphp/Slim/pull/2327.