### PR TITLE
Add 443 as SERVER_PORT(default) when request is https

### DIFF
--- a/src/Environment.php
+++ b/src/Environment.php
@@ -25,14 +25,25 @@ class Environment
      */
     public static function mock(array $userData = [])
     {
+        //Validates if default protocol is HTTPS to set default port 443
+        if ((isset($userData['HTTPS']) && $userData['HTTPS'] !== 'off') ||
+            ((isset($userData['REQUEST_SCHEME']) && $userData['REQUEST_SCHEME'] === 'https'))) {
+            $defscheme = 'https';
+            $defport = 443;
+        } else {
+            $defscheme = 'http';
+            $defport = 80;
+        }
+
         return array_merge([
             'SERVER_PROTOCOL'      => 'HTTP/1.1',
             'REQUEST_METHOD'       => 'GET',
+            'REQUEST_SCHEME'       => $defscheme,
             'SCRIPT_NAME'          => '',
             'REQUEST_URI'          => '',
             'QUERY_STRING'         => '',
             'SERVER_NAME'          => 'localhost',
-            'SERVER_PORT'          => 80,
+            'SERVER_PORT'          => $defport,
             'HTTP_HOST'            => 'localhost',
             'HTTP_ACCEPT'          => 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
             'HTTP_ACCEPT_LANGUAGE' => 'en-US,en;q=0.8',

--- a/tests/EnvironmentTest.php
+++ b/tests/EnvironmentTest.php
@@ -27,4 +27,32 @@ class EnvironmentTest extends TestCase
         $this->assertEquals('/foo/bar?abc=123', $env['REQUEST_URI']);
         $this->assertEquals('localhost', $env['HTTP_HOST']);
     }
+
+    /**
+     * Test environment from mock data with HTTPS
+     */
+    public function testMockHttps()
+    {
+        $env = Environment::mock([
+            'HTTPS' => 'on'
+        ]);
+
+        $this->assertInternalType('array', $env);
+        $this->assertEquals('on', $env['HTTPS']);
+        $this->assertEquals(443, $env['SERVER_PORT']);
+    }
+
+    /**
+     * Test environment from mock data with REQUEST_SCHEME
+     */
+    public function testMockRequestScheme()
+    {
+        $env = Environment::mock([
+            'REQUEST_SCHEME' => 'https'
+        ]);
+
+        $this->assertInternalType('array', $env);
+        $this->assertEquals('https', $env['REQUEST_SCHEME']);
+        $this->assertEquals(443, $env['SERVER_PORT']);
+    }
 }


### PR DESCRIPTION
Same issue fixed on Slim.  Adds HTTPS default port when environment is created,