### PR TITLE
Simplify requestUri detection

### DIFF
--- a/src/Uri.php
+++ b/src/Uri.php
@@ -190,9 +190,7 @@ class Uri implements UriInterface
             }
         }
 
-        // parse_url() requires a full URL. As we don't extract the domain name or scheme, we use a stand-in.
-        $requestUri = parse_url('http://example.com' . $env->get('REQUEST_URI'), PHP_URL_PATH);
-        $requestUri = rawurldecode($requestUri);
+        $requestUri = $env->get('REQUEST_URI');
 
         // Query string
         $queryString = $env->get('QUERY_STRING', '');


### PR DESCRIPTION
We no longer need to worry about parse_url and rawdecode as we're not
doing anything with base paths any more.