### PR TITLE
Update minimum php version to 7.0.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ language: php
 php:
   - 7.0
   - 7.1
+  - 7.2
   - nightly
 
 matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ sudo: false
 language: php
 
 php:
-  - 5.6
   - 7.0
   - 7.1
   - nightly

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
   },
   "require-dev": {
     "squizlabs/php_codesniffer": "^2.5",
-    "phpunit/phpunit": "^7.0",
+    "phpunit/phpunit": "^6.0",
     "php-http/psr7-integration-tests": "dev-master"
   },
   "provide": {

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
   },
   "require-dev": {
     "squizlabs/php_codesniffer": "^2.5",
-    "phpunit/phpunit": "^6.0",
+    "phpunit/phpunit": "^6.0|^7.0",
     "php-http/psr7-integration-tests": "dev-master"
   },
   "provide": {

--- a/composer.json
+++ b/composer.json
@@ -23,12 +23,12 @@
     }
   ],
   "require": {
-    "php": ">=5.6",
+    "php": ">=7.0.0",
     "psr/http-message": "^1.0"
   },
   "require-dev": {
     "squizlabs/php_codesniffer": "^2.5",
-    "phpunit/phpunit": "^5.7|^6.0",
+    "phpunit/phpunit": "^7.0",
     "php-http/psr7-integration-tests": "dev-master"
   },
   "provide": {


### PR DESCRIPTION
Fixes #58 

Updates the minimum version requirement to PHP >= 7.0.0.

Also fixes some of the broken unit tests in PHP 7.1 and higher. These were due to two problems:

1. The way the temp files were created to test uploaded files used tmpfile() which creates a resource, instead of a file name. fopen() no longer allows resources to be passed in. An alternative way to handle this would be to check for a resource and to use it directly, instead of calling fopen(), however we wouldn't be able to guarantee that the `w` flag was used. Opted to just fix how tests were written to use file names instead.
2. In URL creation empty checks were using falsy checks, which matched "0" as well. Updated to use exact `!== ''` checks instead.