### PR TITLE
Remove Unused Dependency php-http/message-factory

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,8 +28,7 @@
     "ext-SimpleXML": "*",
     "php": "^7.1",
     "psr/http-factory": "^1.0",
-    "psr/http-message": "^1.0",
-    "php-http/message-factory": "^1.0"
+    "psr/http-message": "^1.0"
   },
   "require-dev": {
     "nyholm/psr7": "^1.0",
@@ -40,7 +39,7 @@
     "php-http/psr7-integration-tests": "dev-master"
   },
   "provide": {
-    "php-http/message-factory": "^1.0"
+    "psr/http-factory": "^1.0"
   },
   "autoload": {
     "psr-4": {
@@ -53,13 +52,13 @@
     }
   },
   "scripts": {
-      "test": [
-          "@phpunit",
-          "@phpcs",
-          "@phpstan"
-      ],
-      "phpunit": "php vendor/bin/phpunit --process-isolation",
-      "phpcs": "php vendor/bin/phpcs",
-      "phpstan": "php -d memory_limit=-1 vendor/bin/phpstan analyse src tests"
+    "test": [
+      "@phpunit",
+      "@phpcs",
+      "@phpstan"
+    ],
+    "phpunit": "php vendor/bin/phpunit --process-isolation",
+    "phpcs": "php vendor/bin/phpcs",
+    "phpstan": "php -d memory_limit=-1 vendor/bin/phpstan analyse src tests"
   }
 }


### PR DESCRIPTION
`php-http/message-factory` mistakenly made its way into composer.json during the original PR but we are only using `psr/http-factory`.