### PR TITLE
Rename Decorators And Match Original Slim-Http Namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,8 +55,8 @@ $nyholmFactory = new Psr17Factory();
 $decoratedResponseFactory = new DecoratedResponseFactory($nyholmFactory, $nyholmFactory);
 
 /**
- * @var \Slim\Http\Decorators\ResponseDecorator $response
- * The returned variable is a ResponseDecorator which has methods like withJson()
+ * @var \Slim\Http\Response $response
+ * The returned variable is a Response which has methods like withJson()
  */
 $response = $decoratedResponseFactory->createResponse(200, 'OK');
 $response = $response->withJson(['data' => [1, 2, 3]]);
@@ -83,8 +83,8 @@ $streamFactory = new StreamFactory();
 $decoratedResponseFactory = new DecoratedResponseFactory($responseFactory, $streamFactory);
 
 /**
- * @var \Slim\Http\Decorators\ResponseDecorator $response
- * The returned variable is a ResponseDecorator which has methods like withJson()
+ * @var \Slim\Http\Response $response
+ * The returned variable is a Response which has methods like withJson()
  */
 $response = $decoratedResponseFactory->createResponse(200, 'OK');
 $response = $response->withJson(['data' => [1, 2, 3]]);
@@ -95,52 +95,52 @@ $response = $response->withJson(['data' => [1, 2, 3]]);
 ## Decoratored Response Object Methods
 The decorated `ResponseInterface` provides the following additional methods:
 
-#### `ResponseDecorator::withJson($data, $status, $options, $depth)` ####
+#### `Response::withJson($data, $status, $options, $depth)` ####
 | Parameter   | Type    | Description             |
 |-------------|---------|-------------------------|
 | **$data**   | `mixed` | The data to encode      |
 | **$status** | `int`   | The HTTP Status Code    |
 | **$depth**  | `int`   | JSON encoding max depth |
 
-#### `ResponseDecorator::withRedirect($url, $status)` ####
+#### `Response::withRedirect($url, $status)` ####
 | Parameter   | Type     | Description                  |
 |-------------|----------|------------------------------|
 | **$url**    | `string` | The redirect destination url |
 | **$status** | `int`    | The HTTP Status Code         |
 
-#### `ResponseDecorator::write($data)` ####
+#### `Response::write($data)` ####
 | Parameter | Type     | Description                              |
 |-----------|----------|------------------------------------------|
 | **$url**  | `string` | The data to write to the `Response` body |
 
-#### `ResponseDecorator::isClientError()` ####
+#### `Response::isClientError()` ####
 Assert the underlying response's status code is between **400** and **500**.
 
-#### `ResponseDecorator::isEmpty()` ####
+#### `Response::isEmpty()` ####
 Assert the underlying response's status code is **204, 205** or **304**.
 
-#### `ResponseDecorator::isForbidden()` ####
+#### `Response::isForbidden()` ####
 Assert the underlying response's status code is **403**.
 
-#### `ResponseDecorator::isInformational()` ####
+#### `Response::isInformational()` ####
 Assert the underlying response's status code is between **100** and **200**.
 
-#### `ResponseDecorator::isOk()` ####
+#### `Response::isOk()` ####
 Assert the underlying response's status code is **200**.
 
-#### `ResponseDecorator::isNotFound()` ####
+#### `Response::isNotFound()` ####
 Assert the underlying response's status code is **404**.
 
-#### `ResponseDecorator::isRedirection()` ####
+#### `Response::isRedirection()` ####
 Assert the underlying response's status code is between **300** and **400**.
 
-#### `ResponseDecorator::isServerError()` ####
+#### `Response::isServerError()` ####
 Assert the underlying response's status code is between **500** and **600**.
 
-#### `ResponseDecorator::isSuccessful()` ####
+#### `Response::isSuccessful()` ####
 Assert the underlying response's status code is between **200** and **300**.
 
-#### `ResponseDecorator::__toString()` ####
+#### `Response::__toString()` ####
 Will return a string formatted representation of the underlying response object.
 ```
 HTTP/1.1 200 OK
@@ -153,33 +153,33 @@ Content-Type: application/json;charset=utf-8
 ## Decoratored ServerRequest Object Methods
 The decorated `ServerRequestInterface` provides the following additional methods:
 
-#### `ServerRequestDecorator::withAttributes($attributes)` ####
+#### `ServerRequest::withAttributes($attributes)` ####
 | Parameter       | Type      | Description                              |
 |-----------------|-----------|------------------------------------------|
 | **$attributes** | `array`   | Attributes to be appended to the request |
 
-#### `ServerRequestDecorator::getContentCharset()` ####
+#### `ServerRequest::getContentCharset()` ####
 Returns the detected charset from the `Content-Type` header of the underlying server request object. Returns `null` if no value is present.
 
-#### `ServerRequestDecorator::getContentType()` ####
+#### `ServerRequest::getContentType()` ####
 Returns the value from the `Content-Type` header of the underlying server request object. Returns `null` if no value is present.
 
-#### `ServerRequestDecorator::getContentLength()` ####
+#### `ServerRequest::getContentLength()` ####
 Returns the value from the `Content-Length` header of the underlying server request object. Returns `null` if no value is present.
 
-#### `ServerRequestDecorator::getCookieParam($key, $default)` ####
+#### `ServerRequest::getCookieParam($key, $default)` ####
 | Parameter     | Type     | Description                                            |
 |---------------|----------|--------------------------------------------------------|
 | **$key**      | `string` | The attribute name                                     |
 | **$default**  | `mixed`  | Default value to return if the attribute does not exist |
 
-#### `ServerRequestDecorator::getMediaType()` ####
+#### `ServerRequest::getMediaType()` ####
 Returns the first detected value from the `Content-Type` header of the underlying server request object. Returns `null` if no value is present.
 
-#### `ServerRequestDecorator::getMediaTypeParams()` ####
+#### `ServerRequest::getMediaTypeParams()` ####
 Returns an array of detected values from the `Content-Type` header of the underlying server request object. Returns an empty array if no values are present.
 
-#### `ServerRequestDecorator::getParam($key, $default)` ####
+#### `ServerRequest::getParam($key, $default)` ####
 Returns the value from key in `$_POST` or `$_GET`
 
 | Parameter    | Type     | Description                                             |
@@ -187,20 +187,20 @@ Returns the value from key in `$_POST` or `$_GET`
 | **$key**     | `string` | The attribute name                                      |
 | **$default** | `mixed`  | Default value to return if the attribute does not exist |
 
-#### `ServerRequestDecorator::getParams()` ####
+#### `ServerRequest::getParams()` ####
 Returns a merged associative array of the `$_POST` and `$_GET` parameters.
 
-#### `ServerRequestDecorator::getParsedBody()` ####
+#### `ServerRequest::getParsedBody()` ####
 Returns the parsed body from the underlying server request object if it already has been parsed by the underlying PSR-7 implementation. If the parsed body is empty, our decorator attempts to detect the content type and parse the body using one of the registered media type parsers.
 
 The default media type parsers support:
 - JSON
 - XML
 
-You can register your own media type parser using the `ServerRequestDecorator::registerMediaTypeParser()` method.
+You can register your own media type parser using the `ServerRequest::registerMediaTypeParser()` method.
 
 
-#### `ServerRequestDecorator::getParsedBodyParam($key, $default)` ####
+#### `ServerRequest::getParsedBodyParam($key, $default)` ####
 Returns the value from key in the parsed body of the underlying server request object.
 
 | Parameter    | Type     | Description                                             |
@@ -208,7 +208,7 @@ Returns the value from key in the parsed body of the underlying server request o
 | **$key**     | `string` | The attribute name                                      |
 | **$default** | `mixed`  | Default value to return if the attribute does not exist |
 
-#### `ServerRequestDecorator::getQueryParam($key, $default)` ####
+#### `ServerRequest::getQueryParam($key, $default)` ####
 Returns the value from key in the parsed `ServerRequest` query string
 
 | Parameter     | Type     | Description                                             |
@@ -216,7 +216,7 @@ Returns the value from key in the parsed `ServerRequest` query string
 | **$key**      | `string` | The attribute name                                      |
 | **$default**  | `mixed`  | Default value to return if the attribute does not exist |
 
-#### `ServerRequestDecorator::getServerParam($key, $default)` ####
+#### `ServerRequest::getServerParam($key, $default)` ####
 Returns the value from key in parsed server parameters from the underlying underlying server request object.
 
 | Parameter    | Type     | Description                                              |
@@ -224,7 +224,7 @@ Returns the value from key in parsed server parameters from the underlying under
 | **$key**     | `string` | The attribute name                                       |
 | **$default** | `mixed`  | Default value to return if the attribute does not exist  |
 
-#### `ServerRequestDecorator::registerMediaTypeParser($key, $default)` ####
+#### `ServerRequest::registerMediaTypeParser($key, $default)` ####
 Returns the value from key in parsed server parameters from the underlying server request object.
 
 | Parameter      | Type       | Description                                            |
@@ -232,39 +232,39 @@ Returns the value from key in parsed server parameters from the underlying serve
 | **$mediaType** | `string`   | A HTTP media type (excluding content-type params)      |
 | **$callable**  | `callable` | A callable that returns parsed contents for media type |
 
-#### `ServerRequestDecorator::isMethod($method)` ####
+#### `ServerRequest::isMethod($method)` ####
 | Parameter   | Type     | Description     |
 |-------------|----------|-----------------|
 | **$method** | `string` | The method name |
 
-#### `ServerRequestDecorator::isDelete()` ####
+#### `ServerRequest::isDelete()` ####
 Asserts that the underlying server request's method is `DELETE`
 
-#### `ServerRequestDecorator::isGet()` ####
+#### `ServerRequest::isGet()` ####
 Asserts that the underlying server request's method is `GET`
 
-#### `ServerRequestDecorator::isHead()` ####
+#### `ServerRequest::isHead()` ####
 Asserts that the underlying server request's method is `HEAD`
 
-#### `ServerRequestDecorator::isOptions()` ####
+#### `ServerRequest::isOptions()` ####
 Asserts that the underlying server request's method is `OPTIONS`
 
-#### `ServerRequestDecorator::isPatch()` ####
+#### `ServerRequest::isPatch()` ####
 Asserts that the underlying server request's method is `PATCH`
 
-#### `ServerRequestDecorator::isPost()` ####
+#### `ServerRequest::isPost()` ####
 Asserts that the underlying server request's method is `POST`
 
-#### `ServerRequestDecorator::isPut()` ####
+#### `ServerRequest::isPut()` ####
 Asserts that the underlying server request's method is `PUT`
 
-#### `ServerRequestDecorator::isXhr()` ####
+#### `ServerRequest::isXhr()` ####
 Asserts that the header `X-Requested-With` from the underlying server request is `XMLHttpRequest`
 
 ## Decorated Uri Object Methods
 The decorated `UriInterface` provides the following additional methods:
 
-#### `UriDecorator::getBaseUrl()` ####
+#### `Uri::getBaseUrl()` ####
 Returns the fully qualified base URL of the underlying uri object.
 
 ## Contributing

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,7 +1,7 @@
 parameters:
   level: max
   ignoreErrors:
-    - '#Access to an undefined property Slim\\Http\\Decorators\\ResponseDecorator::\$foo#'
-    - '#Access to an undefined property Slim\\Http\\Decorators\\ServerRequestDecorator::\$foo#'
-    - '#Access to an undefined property Slim\\Http\\Decorators\\UriDecorator::\$foo#'
-    - '#Parameter \#1 \$port of method Slim\\Http\\Decorators\\UriDecorator::withPort() expects int|null, string given#'
+    - '#Access to an undefined property Slim\\Http\\Response::\$foo#'
+    - '#Access to an undefined property Slim\\Http\\ServerRequest::\$foo#'
+    - '#Access to an undefined property Slim\\Http\\Uri::\$foo#'
+    - '#Parameter \#1 \$port of method Slim\\Http\\Uri::withPort() expects int|null, string given#'

--- a/src/Factory/DecoratedResponseFactory.php
+++ b/src/Factory/DecoratedResponseFactory.php
@@ -11,7 +11,7 @@ namespace Slim\Http\Factory;
 use Psr\Http\Message\ResponseFactoryInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\StreamFactoryInterface;
-use Slim\Http\Decorators\ResponseDecorator;
+use Slim\Http\Response;
 
 /**
  * Class DecoratedResponseFactory
@@ -43,11 +43,11 @@ class DecoratedResponseFactory implements ResponseFactoryInterface
     /**
      * @param int $code
      * @param string $reasonPhrase
-     * @return ResponseDecorator
+     * @return Response
      */
     public function createResponse(int $code = 200, string $reasonPhrase = ''): ResponseInterface
     {
         $response = $this->responseFactory->createResponse($code, $reasonPhrase);
-        return new ResponseDecorator($response, $this->streamFactory);
+        return new Response($response, $this->streamFactory);
     }
 }

--- a/src/Factory/DecoratedServerRequestFactory.php
+++ b/src/Factory/DecoratedServerRequestFactory.php
@@ -10,7 +10,7 @@ namespace Slim\Http\Factory;
 
 use Psr\Http\Message\ServerRequestFactoryInterface;
 use Psr\Http\Message\ServerRequestInterface;
-use Slim\Http\Decorators\ServerRequestDecorator;
+use Slim\Http\ServerRequest;
 
 /**
  * Class DecoratedServerRequestFactory
@@ -36,11 +36,11 @@ class DecoratedServerRequestFactory implements ServerRequestFactoryInterface
      * @param string $method
      * @param \Psr\Http\Message\UriInterface|string $uri
      * @param array $serverParams
-     * @return ServerRequestDecorator
+     * @return ServerRequest
      */
     public function createServerRequest(string $method, $uri, array $serverParams = []): ServerRequestInterface
     {
         $serverRequest = $this->serverRequestFactory->createServerRequest($method, $uri, $serverParams);
-        return new ServerRequestDecorator($serverRequest);
+        return new ServerRequest($serverRequest);
     }
 }

--- a/src/Factory/DecoratedUriFactory.php
+++ b/src/Factory/DecoratedUriFactory.php
@@ -10,7 +10,7 @@ namespace Slim\Http\Factory;
 
 use Psr\Http\Message\UriFactoryInterface;
 use Psr\Http\Message\UriInterface;
-use Slim\Http\Decorators\UriDecorator;
+use Slim\Http\Uri;
 
 /**
  * Class DecoratedUriFactory
@@ -34,11 +34,11 @@ class DecoratedUriFactory implements UriFactoryInterface
 
     /**
      * @param string $uri
-     * @return UriDecorator
+     * @return Uri
      */
     public function createUri(string $uri = ''): UriInterface
     {
         $uri = $this->uriFactory->createUri($uri);
-        return new UriDecorator($uri);
+        return new Uri($uri);
     }
 }

--- a/src/Response.php
+++ b/src/Response.php
@@ -6,7 +6,7 @@
  * @copyright Copyright (c) 2011-2018 Josh Lockhart
  * @license   https://github.com/slimphp/Slim-Http/blob/master/LICENSE (MIT License)
  */
-namespace Slim\Http\Decorators;
+namespace Slim\Http;
 
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\StreamFactoryInterface;
@@ -15,10 +15,10 @@ use InvalidArgumentException;
 use RuntimeException;
 
 /**
- * Class ResponseDecorator
- * @package Slim\Http\Decorators
+ * Class Response
+ * @package Slim\Http
  */
-class ResponseDecorator implements ResponseInterface
+class Response implements ResponseInterface
 {
     /**
      * @var ResponseInterface;
@@ -38,7 +38,7 @@ class ResponseDecorator implements ResponseInterface
     const EOL = "\r\n";
 
     /**
-     * ResponseDecorator constructor.
+     * Response constructor.
      * @param ResponseInterface $response
      * @param StreamFactoryInterface $streamFactory
      */
@@ -209,13 +209,13 @@ class ResponseDecorator implements ResponseInterface
      *
      * @param string $name Case-insensitive header field name to add.
      * @param string|string[] $value Header value(s).
-     * @return ResponseDecorator
+     * @return Response
      * @throws InvalidArgumentException for invalid header names or values.
      */
     public function withAddedHeader($name, $value)
     {
         $response = $this->response->withAddedHeader($name, $value);
-        return new ResponseDecorator($response, $this->streamFactory);
+        return new Response($response, $this->streamFactory);
     }
 
     /**
@@ -228,13 +228,13 @@ class ResponseDecorator implements ResponseInterface
      * new body stream.
      *
      * @param StreamInterface $body Body.
-     * @return ResponseDecorator
+     * @return Response
      * @throws InvalidArgumentException When the body is not valid.
      */
     public function withBody(StreamInterface $body)
     {
         $response = $this->response->withBody($body);
-        return new ResponseDecorator($response, $this->streamFactory);
+        return new Response($response, $this->streamFactory);
     }
 
     /**
@@ -249,13 +249,13 @@ class ResponseDecorator implements ResponseInterface
      *
      * @param string $name Case-insensitive header field name.
      * @param string|string[] $value Header value(s).
-     * @return ResponseDecorator
+     * @return Response
      * @throws InvalidArgumentException for invalid header names or values.
      */
     public function withHeader($name, $value)
     {
         $response = $this->response->withHeader($name, $value);
-        return new ResponseDecorator($response, $this->streamFactory);
+        return new Response($response, $this->streamFactory);
     }
 
     /**
@@ -268,12 +268,12 @@ class ResponseDecorator implements ResponseInterface
      * the named header.
      *
      * @param string $name Case-insensitive header field name to remove.
-     * @return ResponseDecorator
+     * @return Response
      */
     public function withoutHeader($name)
     {
         $response = $this->response->withoutHeader($name);
-        return new ResponseDecorator($response, $this->streamFactory);
+        return new Response($response, $this->streamFactory);
     }
 
     /**
@@ -287,12 +287,12 @@ class ResponseDecorator implements ResponseInterface
      * new protocol version.
      *
      * @param string $version HTTP protocol version
-     * @return ResponseDecorator
+     * @return Response
      */
     public function withProtocolVersion($version)
     {
         $response = $this->response->withProtocolVersion($version);
-        return new ResponseDecorator($response, $this->streamFactory);
+        return new Response($response, $this->streamFactory);
     }
 
     /**
@@ -312,13 +312,13 @@ class ResponseDecorator implements ResponseInterface
      * @param string $reasonPhrase The reason phrase to use with the
      *     provided status code; if none is provided, implementations MAY
      *     use the defaults as suggested in the HTTP specification.
-     * @return ResponseDecorator
+     * @return Response
      * @throws InvalidArgumentException For invalid status code arguments.
      */
     public function withStatus($code, $reasonPhrase = '')
     {
         $response = $this->response->withStatus($code, $reasonPhrase);
-        return new ResponseDecorator($response, $this->streamFactory);
+        return new Response($response, $this->streamFactory);
     }
 
     /**
@@ -333,7 +333,7 @@ class ResponseDecorator implements ResponseInterface
      * @param  int    $status The HTTP status code.
      * @param  int    $options Json encoding options
      * @param  int    $depth Json encoding max depth
-     * @return ResponseDecorator
+     * @return Response
      */
     public function withJson($data, int $status = null, int $options = 0, int $depth = 512): ResponseInterface
     {
@@ -351,7 +351,7 @@ class ResponseDecorator implements ResponseInterface
             $response = $response->withStatus($status);
         }
 
-        return new ResponseDecorator($response, $this->streamFactory);
+        return new Response($response, $this->streamFactory);
     }
 
     /**

--- a/src/ServerRequest.php
+++ b/src/ServerRequest.php
@@ -6,7 +6,7 @@
  * @copyright Copyright (c) 2011-2018 Josh Lockhart
  * @license   https://github.com/slimphp/Slim-Http/blob/master/LICENSE (MIT License)
  */
-namespace Slim\Http\Decorators;
+namespace Slim\Http;
 
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Message\StreamInterface;
@@ -16,10 +16,10 @@ use InvalidArgumentException;
 use RuntimeException;
 
 /**
- * Class ServerRequestDecorator
- * @package Slim\Http\Decorators
+ * Class ServerRequest
+ * @package Slim\Http
  */
-class ServerRequestDecorator implements ServerRequestInterface
+class ServerRequest implements ServerRequestInterface
 {
     /**
      * @var ServerRequestInterface
@@ -32,7 +32,7 @@ class ServerRequestDecorator implements ServerRequestInterface
     private $bodyParsers;
 
     /**
-     * ServerRequestDecorator constructor.
+     * ServerRequest constructor.
      * @param ServerRequestInterface $serverRequest
      */
     public function __construct(ServerRequestInterface $serverRequest)
@@ -420,13 +420,13 @@ class ServerRequestDecorator implements ServerRequestInterface
      *
      * @param string $name Case-insensitive header field name to add.
      * @param string|string[] $value Header value(s).
-     * @return ServerRequestDecorator
+     * @return ServerRequest
      * @throws InvalidArgumentException for invalid header names or values.
      */
     public function withAddedHeader($name, $value)
     {
         $serverRequest = $this->serverRequest->withAddedHeader($name, $value);
-        return new ServerRequestDecorator($serverRequest);
+        return new ServerRequest($serverRequest);
     }
 
     /**
@@ -442,12 +442,12 @@ class ServerRequestDecorator implements ServerRequestInterface
      * @see getAttributes()
      * @param string $name The attribute name.
      * @param mixed $value The value of the attribute.
-     * @return ServerRequestDecorator
+     * @return ServerRequest
      */
     public function withAttribute($name, $value)
     {
         $serverRequest = $this->serverRequest->withAttribute($name, $value);
-        return new ServerRequestDecorator($serverRequest);
+        return new ServerRequest($serverRequest);
     }
 
     /**
@@ -463,7 +463,7 @@ class ServerRequestDecorator implements ServerRequestInterface
      * updated attributes.
      *
      * @param  array $attributes New attributes
-     * @return ServerRequestDecorator
+     * @return ServerRequest
      */
     public function withAttributes(array $attributes)
     {
@@ -473,7 +473,7 @@ class ServerRequestDecorator implements ServerRequestInterface
             $serverRequest = $serverRequest->withAttribute($attribute, $value);
         }
 
-        return new ServerRequestDecorator($serverRequest);
+        return new ServerRequest($serverRequest);
     }
 
     /**
@@ -488,12 +488,12 @@ class ServerRequestDecorator implements ServerRequestInterface
      *
      * @see getAttributes()
      * @param string $name The attribute name.
-     * @return ServerRequestDecorator
+     * @return ServerRequest
      */
     public function withoutAttribute($name)
     {
         $serverRequest = $this->serverRequest->withoutAttribute($name);
-        return new ServerRequestDecorator($serverRequest);
+        return new ServerRequest($serverRequest);
     }
 
     /**
@@ -506,13 +506,13 @@ class ServerRequestDecorator implements ServerRequestInterface
      * new body stream.
      *
      * @param StreamInterface $body Body.
-     * @return ServerRequestDecorator
+     * @return ServerRequest
      * @throws InvalidArgumentException When the body is not valid.
      */
     public function withBody(StreamInterface $body)
     {
         $serverRequest = $this->serverRequest->withBody($body);
-        return new ServerRequestDecorator($serverRequest);
+        return new ServerRequest($serverRequest);
     }
 
     /**
@@ -530,12 +530,12 @@ class ServerRequestDecorator implements ServerRequestInterface
      * updated cookie values.
      *
      * @param array $cookies Array of key/value pairs representing cookies.
-     * @return ServerRequestDecorator
+     * @return ServerRequest
      */
     public function withCookieParams(array $cookies)
     {
         $serverRequest = $this->serverRequest->withCookieParams($cookies);
-        return new ServerRequestDecorator($serverRequest);
+        return new ServerRequest($serverRequest);
     }
 
     /**
@@ -550,13 +550,13 @@ class ServerRequestDecorator implements ServerRequestInterface
      *
      * @param string $name Case-insensitive header field name.
      * @param string|string[] $value Header value(s).
-     * @return ServerRequestDecorator
+     * @return ServerRequest
      * @throws InvalidArgumentException for invalid header names or values.
      */
     public function withHeader($name, $value)
     {
         $serverRequest = $this->serverRequest->withHeader($name, $value);
-        return new ServerRequestDecorator($serverRequest);
+        return new ServerRequest($serverRequest);
     }
 
     /**
@@ -569,12 +569,12 @@ class ServerRequestDecorator implements ServerRequestInterface
      * the named header.
      *
      * @param string $name Case-insensitive header field name to remove.
-     * @return ServerRequestDecorator
+     * @return ServerRequest
      */
     public function withoutHeader($name)
     {
         $serverRequest = $this->serverRequest->withoutHeader($name);
-        return new ServerRequestDecorator($serverRequest);
+        return new ServerRequest($serverRequest);
     }
 
     /**
@@ -589,13 +589,13 @@ class ServerRequestDecorator implements ServerRequestInterface
      * changed request method.
      *
      * @param string $method Case-sensitive method.
-     * @return ServerRequestDecorator
+     * @return ServerRequest
      * @throws InvalidArgumentException for invalid HTTP methods.
      */
     public function withMethod($method)
     {
         $serverRequest = $this->serverRequest->withMethod($method);
-        return new ServerRequestDecorator($serverRequest);
+        return new ServerRequest($serverRequest);
     }
 
     /**
@@ -622,14 +622,14 @@ class ServerRequestDecorator implements ServerRequestInterface
      *
      * @param null|array|object $data The deserialized body data. This will
      *     typically be in an array or object.
-     * @return ServerRequestDecorator
+     * @return ServerRequest
      * @throws InvalidArgumentException if an unsupported argument type is
      *     provided.
      */
     public function withParsedBody($data)
     {
         $serverRequest = $this->serverRequest->withParsedBody($data);
-        return new ServerRequestDecorator($serverRequest);
+        return new ServerRequest($serverRequest);
     }
 
     /**
@@ -643,12 +643,12 @@ class ServerRequestDecorator implements ServerRequestInterface
      * new protocol version.
      *
      * @param string $version HTTP protocol version
-     * @return ServerRequestDecorator
+     * @return ServerRequest
      */
     public function withProtocolVersion($version)
     {
         $serverRequest = $this->serverRequest->withProtocolVersion($version);
-        return new ServerRequestDecorator($serverRequest);
+        return new ServerRequest($serverRequest);
     }
 
     /**
@@ -671,12 +671,12 @@ class ServerRequestDecorator implements ServerRequestInterface
      *
      * @param array $query Array of query string arguments, typically from
      *     $_GET.
-     * @return ServerRequestDecorator
+     * @return ServerRequest
      */
     public function withQueryParams(array $query)
     {
         $serverRequest = $this->serverRequest->withQueryParams($query);
-        return new ServerRequestDecorator($serverRequest);
+        return new ServerRequest($serverRequest);
     }
 
     /**
@@ -694,12 +694,12 @@ class ServerRequestDecorator implements ServerRequestInterface
      * @link http://tools.ietf.org/html/rfc7230#section-5.3 (for the various
      *     request-target forms allowed in request messages)
      * @param mixed $requestTarget
-     * @return ServerRequestDecorator
+     * @return ServerRequest
      */
     public function withRequestTarget($requestTarget)
     {
         $serverRequest = $this->serverRequest->withRequestTarget($requestTarget);
-        return new ServerRequestDecorator($serverRequest);
+        return new ServerRequest($serverRequest);
     }
 
     /**
@@ -710,13 +710,13 @@ class ServerRequestDecorator implements ServerRequestInterface
      * updated body parameters.
      *
      * @param array $uploadedFiles An array tree of UploadedFileInterface instances.
-     * @return ServerRequestDecorator
+     * @return ServerRequest
      * @throws InvalidArgumentException if an invalid structure is provided.
      */
     public function withUploadedFiles(array $uploadedFiles)
     {
         $serverRequest = $this->serverRequest->withUploadedFiles($uploadedFiles);
-        return new ServerRequestDecorator($serverRequest);
+        return new ServerRequest($serverRequest);
     }
 
     /**
@@ -747,12 +747,12 @@ class ServerRequestDecorator implements ServerRequestInterface
      * @link http://tools.ietf.org/html/rfc3986#section-4.3
      * @param UriInterface $uri New request URI to use.
      * @param bool $preserveHost Preserve the original state of the Host header.
-     * @return ServerRequestDecorator
+     * @return ServerRequest
      */
     public function withUri(UriInterface $uri, $preserveHost = false)
     {
         $serverRequest = $this->serverRequest->withUri($uri, $preserveHost);
-        return new ServerRequestDecorator($serverRequest);
+        return new ServerRequest($serverRequest);
     }
 
     /**

--- a/src/Uri.php
+++ b/src/Uri.php
@@ -6,16 +6,16 @@
  * @copyright Copyright (c) 2011-2018 Josh Lockhart
  * @license   https://github.com/slimphp/Slim-Http/blob/master/LICENSE (MIT License)
  */
-namespace Slim\Http\Decorators;
+namespace Slim\Http;
 
 use Psr\Http\Message\UriInterface;
 use InvalidArgumentException;
 
 /**
- * Class UriDecorator
- * @package Slim\Http\Decorators
+ * Class Uri
+ * @package Slim\Http
  */
-class UriDecorator implements UriInterface
+class Uri implements UriInterface
 {
     /**
      * @var UriInterface
@@ -23,7 +23,7 @@ class UriDecorator implements UriInterface
     private $uri;
 
     /**
-     * UriDecorator constructor.
+     * Uri constructor.
      * @param UriInterface $uri
      */
     public function __construct(UriInterface $uri)
@@ -226,12 +226,12 @@ class UriDecorator implements UriInterface
      * An empty fragment value is equivalent to removing the fragment.
      *
      * @param string $fragment The fragment to use with the new instance.
-     * @return UriDecorator A new instance with the specified fragment.
+     * @return Uri A new instance with the specified fragment.
      */
     public function withFragment($fragment)
     {
         $uri = $this->uri->withFragment($fragment);
-        return new UriDecorator($uri);
+        return new Uri($uri);
     }
 
     /**
@@ -243,13 +243,13 @@ class UriDecorator implements UriInterface
      * An empty host value is equivalent to removing the host.
      *
      * @param string $host The hostname to use with the new instance.
-     * @return UriDecorator A new instance with the specified host.
+     * @return Uri A new instance with the specified host.
      * @throws InvalidArgumentException for invalid hostnames.
      */
     public function withHost($host)
     {
         $uri = $this->uri->withHost($host);
-        return new UriDecorator($uri);
+        return new Uri($uri);
     }
 
     /**
@@ -271,13 +271,13 @@ class UriDecorator implements UriInterface
      * Implementations ensure the correct encoding as outlined in getPath().
      *
      * @param string $path The path to use with the new instance.
-     * @return UriDecorator A new instance with the specified path.
+     * @return Uri A new instance with the specified path.
      * @throws InvalidArgumentException for invalid paths.
      */
     public function withPath($path)
     {
         $uri = $this->uri->withPath($path);
-        return new UriDecorator($uri);
+        return new Uri($uri);
     }
 
     /**
@@ -294,13 +294,13 @@ class UriDecorator implements UriInterface
      *
      * @param null|int $port The port to use with the new instance; a null value
      *     removes the port information.
-     * @return UriDecorator A new instance with the specified port.
+     * @return Uri A new instance with the specified port.
      * @throws InvalidArgumentException for invalid ports.
      */
     public function withPort($port)
     {
         $uri = $this->uri->withPort($port);
-        return new UriDecorator($uri);
+        return new Uri($uri);
     }
 
     /**
@@ -315,13 +315,13 @@ class UriDecorator implements UriInterface
      * An empty query string value is equivalent to removing the query string.
      *
      * @param string $query The query string to use with the new instance.
-     * @return UriDecorator A new instance with the specified query string.
+     * @return Uri A new instance with the specified query string.
      * @throws InvalidArgumentException for invalid query strings.
      */
     public function withQuery($query)
     {
         $uri = $this->uri->withQuery($query);
-        return new UriDecorator($uri);
+        return new Uri($uri);
     }
 
     /**
@@ -336,13 +336,13 @@ class UriDecorator implements UriInterface
      * An empty scheme is equivalent to removing the scheme.
      *
      * @param string $scheme The scheme to use with the new instance.
-     * @return UriDecorator A new instance with the specified scheme.
+     * @return Uri A new instance with the specified scheme.
      * @throws InvalidArgumentException for invalid or unsupported schemes.
      */
     public function withScheme($scheme)
     {
         $uri = $this->uri->withScheme($scheme);
-        return new UriDecorator($uri);
+        return new Uri($uri);
     }
 
     /**
@@ -357,12 +357,12 @@ class UriDecorator implements UriInterface
      *
      * @param string $user The user name to use for authority.
      * @param null|string $password The password associated with $user.
-     * @return UriDecorator A new instance with the specified user information.
+     * @return Uri A new instance with the specified user information.
      */
     public function withUserInfo($user, $password = null)
     {
         $uri = $this->uri->withUserInfo($user, $password);
-        return new UriDecorator($uri);
+        return new Uri($uri);
     }
 
     /**

--- a/tests/ResponseTest.php
+++ b/tests/ResponseTest.php
@@ -6,14 +6,13 @@
  * @copyright Copyright (c) 2011-2018 Josh Lockhart
  * @license   https://github.com/slimphp/Slim-Http/blob/master/LICENSE (MIT License)
  */
-namespace Slim\Tests\Http\Decorators;
+namespace Slim\Tests\Http;
 
-use Slim\Http\Decorators\ResponseDecorator;
+use Slim\Http\Response;
 use Slim\Http\Factory\DecoratedResponseFactory;
 use Slim\Tests\Http\Providers\Psr17FactoryProvider;
-use Slim\Tests\Http\Test;
 
-class ResponseDecoratorTest extends Test
+class ResponseTest extends TestCase
 {
     public function testDisableSetter()
     {
@@ -354,8 +353,8 @@ class ResponseDecoratorTest extends Test
 
     public function testToString()
     {
-        $output = 'HTTP/1.1 404 Not Found' . ResponseDecorator::EOL .
-            'X-Foo: Bar' . ResponseDecorator::EOL . ResponseDecorator::EOL .
+        $output = 'HTTP/1.1 404 Not Found' . Response::EOL .
+            'X-Foo: Bar' . Response::EOL . Response::EOL .
             'Where am I?';
 
         $expectedOutputString = '';
@@ -391,7 +390,7 @@ class ResponseDecoratorTest extends Test
                 $provider->getStreamFactory()
             );
 
-            /** @var ResponseDecorator $originalResponse */
+            /** @var Response $originalResponse */
             $originalResponse = $decoratedResponseFactory->createResponse(503);
             $response = $originalResponse->withJson($data, 201);
 

--- a/tests/ServerRequestTest.php
+++ b/tests/ServerRequestTest.php
@@ -6,17 +6,16 @@
  * @copyright Copyright (c) 2011-2018 Josh Lockhart
  * @license   https://github.com/slimphp/Slim-Http/blob/master/LICENSE (MIT License)
  */
-namespace Slim\Tests\Http\Decorators;
+namespace Slim\Tests\Http;
 
 use Slim\Http\Factory\DecoratedServerRequestFactory;
 use Slim\Tests\Http\Providers\Psr17FactoryProvider;
-use Slim\Tests\Http\Test;
 
 /**
- * Class ServerRequestDecoratorTest
- * @package Slim\Tests\Http\Decorators
+ * Class ServerRequestTest
+ * @package Slim\Tests\Http
  */
-class ServerRequestDecoratorTest extends Test
+class ServerRequestTest extends TestCase
 {
     public function testDisableSetter()
     {

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -10,13 +10,13 @@ namespace Slim\Tests\Http;
 
 use Slim\Tests\Http\Providers\NyholmPsr17FactoryProvider;
 use Slim\Tests\Http\Providers\ZendDiactorosPsr17FactoryProvider;
-use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\TestCase as PHPUnitTestCase;
 
 /**
- * Class Test
+ * Class TestCase
  * @package Tests\SlimPsr7Decorators
  */
-abstract class Test extends TestCase
+abstract class TestCase extends PHPUnitTestCase
 {
     /**
      * @var string[]

--- a/tests/UriTest.php
+++ b/tests/UriTest.php
@@ -6,17 +6,16 @@
  * @copyright Copyright (c) 2011-2018 Josh Lockhart
  * @license   https://github.com/slimphp/Slim-Http/blob/master/LICENSE (MIT License)
  */
-namespace Slim\Tests\Http\Decorators;
+namespace Slim\Tests\Http;
 
 use Slim\Http\Factory\DecoratedUriFactory;
 use Slim\Tests\Http\Providers\Psr17FactoryProvider;
-use Slim\Tests\Http\Test;
 
 /**
- * Class UriDecoratorTest
- * @package Slim\Tests\Http\Decorators
+ * Class UriTest
+ * @package Slim\Tests\Http
  */
-class UriDecoratorTest extends Test
+class UriTest extends TestCase
 {
     public function testDisableSetter()
     {


### PR DESCRIPTION
As per our Slack discussion. Removing the `Decorator` keyword and renaming decorated objects to match original Slim-Http namespacing.