### PR TITLE
Decorate responses created by withRedirect helper

### DIFF
--- a/src/Response.php
+++ b/src/Response.php
@@ -374,7 +374,9 @@ class Response implements ResponseInterface
             return $response->withStatus($status);
         }
 
-        return $response->withStatus(302);
+        $response->withStatus(302);
+        
+        return new Response($response, $this->streamFactory);
     }
 
     /**


### PR DESCRIPTION
Currently the withRedirect helper returns the response implementation object instead of a newly decorated response.