### PR TITLE
Decorate responses created by withRedirect helper

### DIFF
--- a/src/Response.php
+++ b/src/Response.php
@@ -364,7 +364,7 @@ class Response implements ResponseInterface
      *
      * @param string $url The redirect destination.
      * @param int|null $status The redirect HTTP status code.
-     * @return ResponseInterface
+     * @return Response
      */
     public function withRedirect(string $url, $status = null): ResponseInterface
     {

--- a/src/Response.php
+++ b/src/Response.php
@@ -370,11 +370,12 @@ class Response implements ResponseInterface
     {
         $response = $this->response->withHeader('Location', $url);
 
-        if (!is_null($status)) {
-            return $response->withStatus($status);
+        if ($status === null) {
+            $status = 302;
         }
+        $response = $response->withStatus($status);
 
-        return $response->withStatus(302);
+        return new Response($response, $this->streamFactory);
     }
 
     /**


### PR DESCRIPTION
Currently the withRedirect helper returns the response implementation object instead of a newly decorated response.