### PR TITLE
Make use of late static binding to allow decorator extension

### DIFF
--- a/src/Response.php
+++ b/src/Response.php
@@ -335,7 +335,7 @@ class Response implements ResponseInterface
      * @param  int    $depth Json encoding max depth
      * @return static
      */
-    public function withJson($data, int $status = null, int $options = 0, int $depth = 512): ResponseInterface
+    public function withJson($data, int $status = null, int $options = 0, int $depth = 512)
     {
         $json = (string) json_encode($data, $options, $depth);
 
@@ -366,7 +366,7 @@ class Response implements ResponseInterface
      * @param int|null $status The redirect HTTP status code.
      * @return static
      */
-    public function withRedirect(string $url, $status = null): ResponseInterface
+    public function withRedirect(string $url, $status = null)
     {
         $response = $this->response->withHeader('Location', $url);
 

--- a/src/Response.php
+++ b/src/Response.php
@@ -209,13 +209,13 @@ class Response implements ResponseInterface
      *
      * @param string $name Case-insensitive header field name to add.
      * @param string|string[] $value Header value(s).
-     * @return Response
+     * @return static
      * @throws InvalidArgumentException for invalid header names or values.
      */
     public function withAddedHeader($name, $value)
     {
         $response = $this->response->withAddedHeader($name, $value);
-        return new Response($response, $this->streamFactory);
+        return new static($response, $this->streamFactory);
     }
 
     /**
@@ -228,13 +228,13 @@ class Response implements ResponseInterface
      * new body stream.
      *
      * @param StreamInterface $body Body.
-     * @return Response
+     * @return static
      * @throws InvalidArgumentException When the body is not valid.
      */
     public function withBody(StreamInterface $body)
     {
         $response = $this->response->withBody($body);
-        return new Response($response, $this->streamFactory);
+        return new static($response, $this->streamFactory);
     }
 
     /**
@@ -249,13 +249,13 @@ class Response implements ResponseInterface
      *
      * @param string $name Case-insensitive header field name.
      * @param string|string[] $value Header value(s).
-     * @return Response
+     * @return static
      * @throws InvalidArgumentException for invalid header names or values.
      */
     public function withHeader($name, $value)
     {
         $response = $this->response->withHeader($name, $value);
-        return new Response($response, $this->streamFactory);
+        return new static($response, $this->streamFactory);
     }
 
     /**
@@ -268,12 +268,12 @@ class Response implements ResponseInterface
      * the named header.
      *
      * @param string $name Case-insensitive header field name to remove.
-     * @return Response
+     * @return static
      */
     public function withoutHeader($name)
     {
         $response = $this->response->withoutHeader($name);
-        return new Response($response, $this->streamFactory);
+        return new static($response, $this->streamFactory);
     }
 
     /**
@@ -287,12 +287,12 @@ class Response implements ResponseInterface
      * new protocol version.
      *
      * @param string $version HTTP protocol version
-     * @return Response
+     * @return static
      */
     public function withProtocolVersion($version)
     {
         $response = $this->response->withProtocolVersion($version);
-        return new Response($response, $this->streamFactory);
+        return new static($response, $this->streamFactory);
     }
 
     /**
@@ -312,13 +312,13 @@ class Response implements ResponseInterface
      * @param string $reasonPhrase The reason phrase to use with the
      *     provided status code; if none is provided, implementations MAY
      *     use the defaults as suggested in the HTTP specification.
-     * @return Response
+     * @return static
      * @throws InvalidArgumentException For invalid status code arguments.
      */
     public function withStatus($code, $reasonPhrase = '')
     {
         $response = $this->response->withStatus($code, $reasonPhrase);
-        return new Response($response, $this->streamFactory);
+        return new static($response, $this->streamFactory);
     }
 
     /**
@@ -333,7 +333,7 @@ class Response implements ResponseInterface
      * @param  int    $status The HTTP status code.
      * @param  int    $options Json encoding options
      * @param  int    $depth Json encoding max depth
-     * @return Response
+     * @return static
      */
     public function withJson($data, int $status = null, int $options = 0, int $depth = 512): ResponseInterface
     {
@@ -351,7 +351,7 @@ class Response implements ResponseInterface
             $response = $response->withStatus($status);
         }
 
-        return new Response($response, $this->streamFactory);
+        return new static($response, $this->streamFactory);
     }
 
     /**
@@ -364,7 +364,7 @@ class Response implements ResponseInterface
      *
      * @param string $url The redirect destination.
      * @param int|null $status The redirect HTTP status code.
-     * @return ResponseInterface
+     * @return static
      */
     public function withRedirect(string $url, $status = null): ResponseInterface
     {

--- a/src/Response.php
+++ b/src/Response.php
@@ -375,7 +375,7 @@ class Response implements ResponseInterface
         }
         $response = $response->withStatus($status);
 
-        return new Response($response, $this->streamFactory);
+        return new static($response, $this->streamFactory);
     }
 
     /**

--- a/src/Response.php
+++ b/src/Response.php
@@ -335,7 +335,7 @@ class Response implements ResponseInterface
      * @param  int    $depth Json encoding max depth
      * @return static
      */
-    public function withJson($data, int $status = null, int $options = 0, int $depth = 512)
+    public function withJson($data, int $status = null, int $options = 0, int $depth = 512): ResponseInterface
     {
         $json = (string) json_encode($data, $options, $depth);
 
@@ -366,7 +366,7 @@ class Response implements ResponseInterface
      * @param int|null $status The redirect HTTP status code.
      * @return static
      */
-    public function withRedirect(string $url, $status = null)
+    public function withRedirect(string $url, $status = null): ResponseInterface
     {
         $response = $this->response->withHeader('Location', $url);
 
@@ -388,7 +388,7 @@ class Response implements ResponseInterface
      * @param string $data
      * @return static
      */
-    public function write($data)
+    public function write($data): ResponseInterface
     {
         $this->response->getBody()->write($data);
         return $this;

--- a/src/Response.php
+++ b/src/Response.php
@@ -386,7 +386,7 @@ class Response implements ResponseInterface
      * Proxies to the underlying stream and writes the provided data to it.
      *
      * @param string $data
-     * @return self
+     * @return static
      */
     public function write($data)
     {

--- a/src/ServerRequest.php
+++ b/src/ServerRequest.php
@@ -420,13 +420,13 @@ class ServerRequest implements ServerRequestInterface
      *
      * @param string $name Case-insensitive header field name to add.
      * @param string|string[] $value Header value(s).
-     * @return ServerRequest
+     * @return static
      * @throws InvalidArgumentException for invalid header names or values.
      */
     public function withAddedHeader($name, $value)
     {
         $serverRequest = $this->serverRequest->withAddedHeader($name, $value);
-        return new ServerRequest($serverRequest);
+        return new static($serverRequest);
     }
 
     /**
@@ -442,12 +442,12 @@ class ServerRequest implements ServerRequestInterface
      * @see getAttributes()
      * @param string $name The attribute name.
      * @param mixed $value The value of the attribute.
-     * @return ServerRequest
+     * @return static
      */
     public function withAttribute($name, $value)
     {
         $serverRequest = $this->serverRequest->withAttribute($name, $value);
-        return new ServerRequest($serverRequest);
+        return new static($serverRequest);
     }
 
     /**
@@ -463,7 +463,7 @@ class ServerRequest implements ServerRequestInterface
      * updated attributes.
      *
      * @param  array $attributes New attributes
-     * @return ServerRequest
+     * @return static
      */
     public function withAttributes(array $attributes)
     {
@@ -473,7 +473,7 @@ class ServerRequest implements ServerRequestInterface
             $serverRequest = $serverRequest->withAttribute($attribute, $value);
         }
 
-        return new ServerRequest($serverRequest);
+        return new static($serverRequest);
     }
 
     /**
@@ -488,12 +488,12 @@ class ServerRequest implements ServerRequestInterface
      *
      * @see getAttributes()
      * @param string $name The attribute name.
-     * @return ServerRequest
+     * @return static
      */
     public function withoutAttribute($name)
     {
         $serverRequest = $this->serverRequest->withoutAttribute($name);
-        return new ServerRequest($serverRequest);
+        return new static($serverRequest);
     }
 
     /**
@@ -506,13 +506,13 @@ class ServerRequest implements ServerRequestInterface
      * new body stream.
      *
      * @param StreamInterface $body Body.
-     * @return ServerRequest
+     * @return static
      * @throws InvalidArgumentException When the body is not valid.
      */
     public function withBody(StreamInterface $body)
     {
         $serverRequest = $this->serverRequest->withBody($body);
-        return new ServerRequest($serverRequest);
+        return new static($serverRequest);
     }
 
     /**
@@ -530,12 +530,12 @@ class ServerRequest implements ServerRequestInterface
      * updated cookie values.
      *
      * @param array $cookies Array of key/value pairs representing cookies.
-     * @return ServerRequest
+     * @return static
      */
     public function withCookieParams(array $cookies)
     {
         $serverRequest = $this->serverRequest->withCookieParams($cookies);
-        return new ServerRequest($serverRequest);
+        return new static($serverRequest);
     }
 
     /**
@@ -550,13 +550,13 @@ class ServerRequest implements ServerRequestInterface
      *
      * @param string $name Case-insensitive header field name.
      * @param string|string[] $value Header value(s).
-     * @return ServerRequest
+     * @return static
      * @throws InvalidArgumentException for invalid header names or values.
      */
     public function withHeader($name, $value)
     {
         $serverRequest = $this->serverRequest->withHeader($name, $value);
-        return new ServerRequest($serverRequest);
+        return new static($serverRequest);
     }
 
     /**
@@ -569,12 +569,12 @@ class ServerRequest implements ServerRequestInterface
      * the named header.
      *
      * @param string $name Case-insensitive header field name to remove.
-     * @return ServerRequest
+     * @return static
      */
     public function withoutHeader($name)
     {
         $serverRequest = $this->serverRequest->withoutHeader($name);
-        return new ServerRequest($serverRequest);
+        return new static($serverRequest);
     }
 
     /**
@@ -589,13 +589,13 @@ class ServerRequest implements ServerRequestInterface
      * changed request method.
      *
      * @param string $method Case-sensitive method.
-     * @return ServerRequest
+     * @return static
      * @throws InvalidArgumentException for invalid HTTP methods.
      */
     public function withMethod($method)
     {
         $serverRequest = $this->serverRequest->withMethod($method);
-        return new ServerRequest($serverRequest);
+        return new static($serverRequest);
     }
 
     /**
@@ -622,14 +622,14 @@ class ServerRequest implements ServerRequestInterface
      *
      * @param null|array|object $data The deserialized body data. This will
      *     typically be in an array or object.
-     * @return ServerRequest
+     * @return static
      * @throws InvalidArgumentException if an unsupported argument type is
      *     provided.
      */
     public function withParsedBody($data)
     {
         $serverRequest = $this->serverRequest->withParsedBody($data);
-        return new ServerRequest($serverRequest);
+        return new static($serverRequest);
     }
 
     /**
@@ -643,12 +643,12 @@ class ServerRequest implements ServerRequestInterface
      * new protocol version.
      *
      * @param string $version HTTP protocol version
-     * @return ServerRequest
+     * @return static
      */
     public function withProtocolVersion($version)
     {
         $serverRequest = $this->serverRequest->withProtocolVersion($version);
-        return new ServerRequest($serverRequest);
+        return new static($serverRequest);
     }
 
     /**
@@ -671,12 +671,12 @@ class ServerRequest implements ServerRequestInterface
      *
      * @param array $query Array of query string arguments, typically from
      *     $_GET.
-     * @return ServerRequest
+     * @return static
      */
     public function withQueryParams(array $query)
     {
         $serverRequest = $this->serverRequest->withQueryParams($query);
-        return new ServerRequest($serverRequest);
+        return new static($serverRequest);
     }
 
     /**
@@ -694,12 +694,12 @@ class ServerRequest implements ServerRequestInterface
      * @link http://tools.ietf.org/html/rfc7230#section-5.3 (for the various
      *     request-target forms allowed in request messages)
      * @param mixed $requestTarget
-     * @return ServerRequest
+     * @return static
      */
     public function withRequestTarget($requestTarget)
     {
         $serverRequest = $this->serverRequest->withRequestTarget($requestTarget);
-        return new ServerRequest($serverRequest);
+        return new static($serverRequest);
     }
 
     /**
@@ -710,13 +710,13 @@ class ServerRequest implements ServerRequestInterface
      * updated body parameters.
      *
      * @param array $uploadedFiles An array tree of UploadedFileInterface instances.
-     * @return ServerRequest
+     * @return static
      * @throws InvalidArgumentException if an invalid structure is provided.
      */
     public function withUploadedFiles(array $uploadedFiles)
     {
         $serverRequest = $this->serverRequest->withUploadedFiles($uploadedFiles);
-        return new ServerRequest($serverRequest);
+        return new static($serverRequest);
     }
 
     /**
@@ -747,12 +747,12 @@ class ServerRequest implements ServerRequestInterface
      * @link http://tools.ietf.org/html/rfc3986#section-4.3
      * @param UriInterface $uri New request URI to use.
      * @param bool $preserveHost Preserve the original state of the Host header.
-     * @return ServerRequest
+     * @return static
      */
     public function withUri(UriInterface $uri, $preserveHost = false)
     {
         $serverRequest = $this->serverRequest->withUri($uri, $preserveHost);
-        return new ServerRequest($serverRequest);
+        return new static($serverRequest);
     }
 
     /**

--- a/src/ServerRequest.php
+++ b/src/ServerRequest.php
@@ -983,9 +983,9 @@ class ServerRequest implements ServerRequestInterface
      *
      * @param string   $mediaType A HTTP media type (excluding content-type params).
      * @param callable $callable  A callable that returns parsed contents for media type.
-     * @return self
+     * @return static
      */
-    public function registerMediaTypeParser($mediaType, callable $callable)
+    public function registerMediaTypeParser($mediaType, callable $callable): ServerRequestInterface
     {
         if ($callable instanceof Closure) {
             $callable = $callable->bindTo($this);

--- a/src/Uri.php
+++ b/src/Uri.php
@@ -226,12 +226,12 @@ class Uri implements UriInterface
      * An empty fragment value is equivalent to removing the fragment.
      *
      * @param string $fragment The fragment to use with the new instance.
-     * @return Uri A new instance with the specified fragment.
+     * @return static A new instance with the specified fragment.
      */
     public function withFragment($fragment)
     {
         $uri = $this->uri->withFragment($fragment);
-        return new Uri($uri);
+        return new static($uri);
     }
 
     /**
@@ -243,13 +243,13 @@ class Uri implements UriInterface
      * An empty host value is equivalent to removing the host.
      *
      * @param string $host The hostname to use with the new instance.
-     * @return Uri A new instance with the specified host.
+     * @return static A new instance with the specified host.
      * @throws InvalidArgumentException for invalid hostnames.
      */
     public function withHost($host)
     {
         $uri = $this->uri->withHost($host);
-        return new Uri($uri);
+        return new static($uri);
     }
 
     /**
@@ -271,13 +271,13 @@ class Uri implements UriInterface
      * Implementations ensure the correct encoding as outlined in getPath().
      *
      * @param string $path The path to use with the new instance.
-     * @return Uri A new instance with the specified path.
+     * @return static A new instance with the specified path.
      * @throws InvalidArgumentException for invalid paths.
      */
     public function withPath($path)
     {
         $uri = $this->uri->withPath($path);
-        return new Uri($uri);
+        return new static($uri);
     }
 
     /**
@@ -294,13 +294,13 @@ class Uri implements UriInterface
      *
      * @param null|int $port The port to use with the new instance; a null value
      *     removes the port information.
-     * @return Uri A new instance with the specified port.
+     * @return static A new instance with the specified port.
      * @throws InvalidArgumentException for invalid ports.
      */
     public function withPort($port)
     {
         $uri = $this->uri->withPort($port);
-        return new Uri($uri);
+        return new static($uri);
     }
 
     /**
@@ -315,13 +315,13 @@ class Uri implements UriInterface
      * An empty query string value is equivalent to removing the query string.
      *
      * @param string $query The query string to use with the new instance.
-     * @return Uri A new instance with the specified query string.
+     * @return static A new instance with the specified query string.
      * @throws InvalidArgumentException for invalid query strings.
      */
     public function withQuery($query)
     {
         $uri = $this->uri->withQuery($query);
-        return new Uri($uri);
+        return new static($uri);
     }
 
     /**
@@ -336,13 +336,13 @@ class Uri implements UriInterface
      * An empty scheme is equivalent to removing the scheme.
      *
      * @param string $scheme The scheme to use with the new instance.
-     * @return Uri A new instance with the specified scheme.
+     * @return static A new instance with the specified scheme.
      * @throws InvalidArgumentException for invalid or unsupported schemes.
      */
     public function withScheme($scheme)
     {
         $uri = $this->uri->withScheme($scheme);
-        return new Uri($uri);
+        return new static($uri);
     }
 
     /**
@@ -357,12 +357,12 @@ class Uri implements UriInterface
      *
      * @param string $user The user name to use for authority.
      * @param null|string $password The password associated with $user.
-     * @return Uri A new instance with the specified user information.
+     * @return static A new instance with the specified user information.
      */
     public function withUserInfo($user, $password = null)
     {
         $uri = $this->uri->withUserInfo($user, $password);
-        return new Uri($uri);
+        return new static($uri);
     }
 
     /**


### PR DESCRIPTION
We would like to extend the response decorator in order to add additional domain-specific helpers. Unfortunately this is not possible at present as the current helpers do not make use of late static binding.

Using the response as an example, the current helpers take the basic format of:
```
/**
 * @return Response
 */
public function withX(): ResponseInterface
{
    $response = $this->response->withY();
    return new Response($response, $this->streamFactory);
}
```

In order to allow extension it would be nice if these made use of late static binding to type hint and create the new decorated response as follows:
```
/**
 * @return static
 */
public function withX(): ResponseInterface
{
    $response = $this->response->withY();
    return new static($response, $this->streamFactory);
}
```

