### PR TITLE
[WIP] Remove sudo usage from Travis-CI config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,3 @@
-sudo: false
-
 language: php
 
 dist: trusty


### PR DESCRIPTION
Due to upcoming Linux infrastructure migration on Travis-CI we needed to remove `sudo: false` from our configuration.

This is a work in progress as I'm not entirely sure things will work. We shall see in a moment!