### PR TITLE
Add type hints and fix docblocks for \Slim\Http\Response

### DIFF
--- a/src/Response.php
+++ b/src/Response.php
@@ -63,7 +63,7 @@ class Response implements ResponseInterface
     /**
      * {@inheritdoc}
      */
-    public function getHeader($name)
+    public function getHeader($name): array
     {
         return $this->response->getHeader($name);
     }
@@ -71,7 +71,7 @@ class Response implements ResponseInterface
     /**
      * {@inheritdoc}
      */
-    public function getHeaderLine($name)
+    public function getHeaderLine($name): string
     {
         return $this->response->getHeaderLine($name);
     }
@@ -79,7 +79,7 @@ class Response implements ResponseInterface
     /**
      * {@inheritdoc}
      */
-    public function getHeaders()
+    public function getHeaders(): array
     {
         return $this->response->getHeaders();
     }
@@ -87,7 +87,7 @@ class Response implements ResponseInterface
     /**
      * {@inheritdoc}
      */
-    public function getProtocolVersion()
+    public function getProtocolVersion(): string
     {
         return $this->response->getProtocolVersion();
     }
@@ -95,7 +95,7 @@ class Response implements ResponseInterface
     /**
      * {@inheritdoc}
      */
-    public function getReasonPhrase()
+    public function getReasonPhrase(): string
     {
         return $this->response->getReasonPhrase();
     }
@@ -103,7 +103,7 @@ class Response implements ResponseInterface
     /**
      * {@inheritdoc}
      */
-    public function getStatusCode()
+    public function getStatusCode(): int
     {
         return $this->response->getStatusCode();
     }
@@ -111,7 +111,7 @@ class Response implements ResponseInterface
     /**
      * {@inheritdoc}
      */
-    public function hasHeader($name)
+    public function hasHeader($name): bool
     {
         return $this->response->hasHeader($name);
     }
@@ -119,7 +119,7 @@ class Response implements ResponseInterface
     /**
      * {@inheritdoc}
      */
-    public function withAddedHeader($name, $value)
+    public function withAddedHeader($name, $value): self
     {
         $response = $this->response->withAddedHeader($name, $value);
         return new static($response, $this->streamFactory);
@@ -128,7 +128,7 @@ class Response implements ResponseInterface
     /**
      * {@inheritdoc}
      */
-    public function withBody(StreamInterface $body)
+    public function withBody(StreamInterface $body): self
     {
         $response = $this->response->withBody($body);
         return new static($response, $this->streamFactory);
@@ -137,7 +137,7 @@ class Response implements ResponseInterface
     /**
      * {@inheritdoc}
      */
-    public function withHeader($name, $value)
+    public function withHeader($name, $value): self
     {
         $response = $this->response->withHeader($name, $value);
         return new static($response, $this->streamFactory);
@@ -146,7 +146,7 @@ class Response implements ResponseInterface
     /**
      * {@inheritdoc}
      */
-    public function withoutHeader($name)
+    public function withoutHeader($name): self
     {
         $response = $this->response->withoutHeader($name);
         return new static($response, $this->streamFactory);
@@ -155,7 +155,7 @@ class Response implements ResponseInterface
     /**
      * {@inheritdoc}
      */
-    public function withProtocolVersion($version)
+    public function withProtocolVersion($version): self
     {
         $response = $this->response->withProtocolVersion($version);
         return new static($response, $this->streamFactory);
@@ -164,7 +164,7 @@ class Response implements ResponseInterface
     /**
      * {@inheritdoc}
      */
-    public function withStatus($code, $reasonPhrase = '')
+    public function withStatus($code, $reasonPhrase = ''): self
     {
         $response = $this->response->withStatus($code, $reasonPhrase);
         return new static($response, $this->streamFactory);
@@ -178,13 +178,13 @@ class Response implements ResponseInterface
      * This method prepares the response object to return an HTTP Json
      * response to the client.
      *
-     * @param  mixed  $data   The data
-     * @param  int    $status The HTTP status code.
-     * @param  int    $options Json encoding options
-     * @param  int    $depth Json encoding max depth
+     * @param  mixed     $data   The data
+     * @param  int|null  $status The HTTP status code
+     * @param  int       $options Json encoding options
+     * @param  int       $depth Json encoding max depth
      * @return static
      */
-    public function withJson($data, int $status = null, int $options = 0, int $depth = 512): ResponseInterface
+    public function withJson($data, ?int $status = null, int $options = 0, int $depth = 512): ResponseInterface
     {
         $json = (string) json_encode($data, $options, $depth);
 
@@ -211,11 +211,11 @@ class Response implements ResponseInterface
      * This method prepares the response object to return an HTTP Redirect
      * response to the client.
      *
-     * @param string $url The redirect destination.
-     * @param int|null $status The redirect HTTP status code.
+     * @param string    $url The redirect destination.
+     * @param int|null  $status The redirect HTTP status code.
      * @return static
      */
-    public function withRedirect(string $url, $status = null): ResponseInterface
+    public function withRedirect(string $url, ?int $status = null): ResponseInterface
     {
         $response = $this->response->withHeader('Location', $url);
 
@@ -237,7 +237,7 @@ class Response implements ResponseInterface
      * @param string $data
      * @return static
      */
-    public function write($data): ResponseInterface
+    public function write(string $data): ResponseInterface
     {
         $this->response->getBody()->write($data);
         return $this;

--- a/src/Response.php
+++ b/src/Response.php
@@ -17,7 +17,7 @@ use RuntimeException;
 class Response implements ResponseInterface
 {
     /**
-     * @var ResponseInterface;
+     * @var ResponseInterface
      */
     private $response;
 


### PR DESCRIPTION
This PR adds type hints and fixes docblocks for `\Slim\Http\Response`.