### PR TITLE
Add type hints and fix docblocks for \Slim\Http\ServerRequest

### DIFF
--- a/src/ServerRequest.php
+++ b/src/ServerRequest.php
@@ -264,7 +264,7 @@ class ServerRequest implements ServerRequestInterface
     /**
      * {@inheritdoc}
      */
-    public function withAddedHeader($name, $value): self
+    public function withAddedHeader($name, $value)
     {
         $serverRequest = $this->serverRequest->withAddedHeader($name, $value);
         return new static($serverRequest);
@@ -273,7 +273,7 @@ class ServerRequest implements ServerRequestInterface
     /**
      * {@inheritdoc}
      */
-    public function withAttribute($name, $value): self
+    public function withAttribute($name, $value)
     {
         $serverRequest = $this->serverRequest->withAttribute($name, $value);
         return new static($serverRequest);
@@ -294,7 +294,7 @@ class ServerRequest implements ServerRequestInterface
      * @param  array $attributes New attributes
      * @return static
      */
-    public function withAttributes(array $attributes): self
+    public function withAttributes(array $attributes)
     {
         $serverRequest = $this->serverRequest;
 
@@ -308,7 +308,7 @@ class ServerRequest implements ServerRequestInterface
     /**
      * {@inheritdoc}
      */
-    public function withoutAttribute($name): self
+    public function withoutAttribute($name)
     {
         $serverRequest = $this->serverRequest->withoutAttribute($name);
         return new static($serverRequest);
@@ -317,7 +317,7 @@ class ServerRequest implements ServerRequestInterface
     /**
      * {@inheritdoc}
      */
-    public function withBody(StreamInterface $body): self
+    public function withBody(StreamInterface $body)
     {
         $serverRequest = $this->serverRequest->withBody($body);
         return new static($serverRequest);
@@ -326,7 +326,7 @@ class ServerRequest implements ServerRequestInterface
     /**
      * {@inheritdoc}
      */
-    public function withCookieParams(array $cookies): self
+    public function withCookieParams(array $cookies)
     {
         $serverRequest = $this->serverRequest->withCookieParams($cookies);
         return new static($serverRequest);
@@ -335,7 +335,7 @@ class ServerRequest implements ServerRequestInterface
     /**
      * {@inheritdoc}
      */
-    public function withHeader($name, $value): self
+    public function withHeader($name, $value)
     {
         $serverRequest = $this->serverRequest->withHeader($name, $value);
         return new static($serverRequest);
@@ -344,7 +344,7 @@ class ServerRequest implements ServerRequestInterface
     /**
      * {@inheritdoc}
      */
-    public function withoutHeader($name): self
+    public function withoutHeader($name)
     {
         $serverRequest = $this->serverRequest->withoutHeader($name);
         return new static($serverRequest);
@@ -353,7 +353,7 @@ class ServerRequest implements ServerRequestInterface
     /**
      * {@inheritdoc}
      */
-    public function withMethod($method): self
+    public function withMethod($method)
     {
         $serverRequest = $this->serverRequest->withMethod($method);
         return new static($serverRequest);
@@ -362,7 +362,7 @@ class ServerRequest implements ServerRequestInterface
     /**
      * {@inheritdoc}
      */
-    public function withParsedBody($data): self
+    public function withParsedBody($data)
     {
         $serverRequest = $this->serverRequest->withParsedBody($data);
         return new static($serverRequest);
@@ -371,7 +371,7 @@ class ServerRequest implements ServerRequestInterface
     /**
      * {@inheritdoc}
      */
-    public function withProtocolVersion($version): self
+    public function withProtocolVersion($version)
     {
         $serverRequest = $this->serverRequest->withProtocolVersion($version);
         return new static($serverRequest);
@@ -380,7 +380,7 @@ class ServerRequest implements ServerRequestInterface
     /**
      * {@inheritdoc}
      */
-    public function withQueryParams(array $query): self
+    public function withQueryParams(array $query)
     {
         $serverRequest = $this->serverRequest->withQueryParams($query);
         return new static($serverRequest);
@@ -389,7 +389,7 @@ class ServerRequest implements ServerRequestInterface
     /**
      * {@inheritdoc}
      */
-    public function withRequestTarget($requestTarget): self
+    public function withRequestTarget($requestTarget)
     {
         $serverRequest = $this->serverRequest->withRequestTarget($requestTarget);
         return new static($serverRequest);
@@ -398,7 +398,7 @@ class ServerRequest implements ServerRequestInterface
     /**
      * {@inheritdoc}
      */
-    public function withUploadedFiles(array $uploadedFiles): self
+    public function withUploadedFiles(array $uploadedFiles)
     {
         $serverRequest = $this->serverRequest->withUploadedFiles($uploadedFiles);
         return new static($serverRequest);
@@ -407,7 +407,7 @@ class ServerRequest implements ServerRequestInterface
     /**
      * {@inheritdoc}
      */
-    public function withUri(UriInterface $uri, $preserveHost = false): self
+    public function withUri(UriInterface $uri, $preserveHost = false)
     {
         $serverRequest = $this->serverRequest->withUri($uri, $preserveHost);
         return new static($serverRequest);

--- a/src/ServerRequest.php
+++ b/src/ServerRequest.php
@@ -102,7 +102,7 @@ class ServerRequest implements ServerRequestInterface
     /**
      * {@inheritdoc}
      */
-    public function getAttributes()
+    public function getAttributes(): array
     {
         return $this->serverRequest->getAttributes();
     }
@@ -110,7 +110,7 @@ class ServerRequest implements ServerRequestInterface
     /**
      * {@inheritdoc}
      */
-    public function getBody()
+    public function getBody(): StreamInterface
     {
         return $this->serverRequest->getBody();
     }
@@ -118,7 +118,7 @@ class ServerRequest implements ServerRequestInterface
     /**
      * {@inheritdoc}
      */
-    public function getCookieParams()
+    public function getCookieParams(): array
     {
         return $this->serverRequest->getCookieParams();
     }
@@ -126,7 +126,7 @@ class ServerRequest implements ServerRequestInterface
     /**
      * {@inheritdoc}
      */
-    public function getHeader($name)
+    public function getHeader($name): array
     {
         return $this->serverRequest->getHeader($name);
     }
@@ -134,7 +134,7 @@ class ServerRequest implements ServerRequestInterface
     /**
      * {@inheritdoc}
      */
-    public function getHeaderLine($name)
+    public function getHeaderLine($name): string
     {
         return $this->serverRequest->getHeaderLine($name);
     }
@@ -142,7 +142,7 @@ class ServerRequest implements ServerRequestInterface
     /**
      * {@inheritdoc}
      */
-    public function getHeaders()
+    public function getHeaders(): array
     {
         return $this->serverRequest->getHeaders();
     }
@@ -150,7 +150,7 @@ class ServerRequest implements ServerRequestInterface
     /**
      * {@inheritdoc}
      */
-    public function getMethod()
+    public function getMethod(): string
     {
         return $this->serverRequest->getMethod();
     }
@@ -199,7 +199,7 @@ class ServerRequest implements ServerRequestInterface
     /**
      * {@inheritdoc}
      */
-    public function getProtocolVersion()
+    public function getProtocolVersion(): string
     {
         return $this->serverRequest->getProtocolVersion();
     }
@@ -207,7 +207,7 @@ class ServerRequest implements ServerRequestInterface
     /**
      * {@inheritdoc}
      */
-    public function getQueryParams()
+    public function getQueryParams(): array
     {
         $queryParams = $this->serverRequest->getQueryParams();
 
@@ -224,7 +224,7 @@ class ServerRequest implements ServerRequestInterface
     /**
      * {@inheritdoc}
      */
-    public function getRequestTarget()
+    public function getRequestTarget(): string
     {
         return $this->serverRequest->getRequestTarget();
     }
@@ -232,7 +232,7 @@ class ServerRequest implements ServerRequestInterface
     /**
      * {@inheritdoc}
      */
-    public function getServerParams()
+    public function getServerParams(): array
     {
         return $this->serverRequest->getServerParams();
     }
@@ -240,7 +240,7 @@ class ServerRequest implements ServerRequestInterface
     /**
      * {@inheritdoc}
      */
-    public function getUploadedFiles()
+    public function getUploadedFiles(): array
     {
         return $this->serverRequest->getUploadedFiles();
     }
@@ -248,7 +248,7 @@ class ServerRequest implements ServerRequestInterface
     /**
      * {@inheritdoc}
      */
-    public function getUri()
+    public function getUri(): UriInterface
     {
         return $this->serverRequest->getUri();
     }
@@ -256,7 +256,7 @@ class ServerRequest implements ServerRequestInterface
     /**
      * {@inheritdoc}
      */
-    public function hasHeader($name)
+    public function hasHeader($name): bool
     {
         return $this->serverRequest->hasHeader($name);
     }
@@ -264,7 +264,7 @@ class ServerRequest implements ServerRequestInterface
     /**
      * {@inheritdoc}
      */
-    public function withAddedHeader($name, $value)
+    public function withAddedHeader($name, $value): self
     {
         $serverRequest = $this->serverRequest->withAddedHeader($name, $value);
         return new static($serverRequest);
@@ -273,7 +273,7 @@ class ServerRequest implements ServerRequestInterface
     /**
      * {@inheritdoc}
      */
-    public function withAttribute($name, $value)
+    public function withAttribute($name, $value): self
     {
         $serverRequest = $this->serverRequest->withAttribute($name, $value);
         return new static($serverRequest);
@@ -294,7 +294,7 @@ class ServerRequest implements ServerRequestInterface
      * @param  array $attributes New attributes
      * @return static
      */
-    public function withAttributes(array $attributes)
+    public function withAttributes(array $attributes): self
     {
         $serverRequest = $this->serverRequest;
 
@@ -308,7 +308,7 @@ class ServerRequest implements ServerRequestInterface
     /**
      * {@inheritdoc}
      */
-    public function withoutAttribute($name)
+    public function withoutAttribute($name): self
     {
         $serverRequest = $this->serverRequest->withoutAttribute($name);
         return new static($serverRequest);
@@ -317,7 +317,7 @@ class ServerRequest implements ServerRequestInterface
     /**
      * {@inheritdoc}
      */
-    public function withBody(StreamInterface $body)
+    public function withBody(StreamInterface $body): self
     {
         $serverRequest = $this->serverRequest->withBody($body);
         return new static($serverRequest);
@@ -326,7 +326,7 @@ class ServerRequest implements ServerRequestInterface
     /**
      * {@inheritdoc}
      */
-    public function withCookieParams(array $cookies)
+    public function withCookieParams(array $cookies): self
     {
         $serverRequest = $this->serverRequest->withCookieParams($cookies);
         return new static($serverRequest);
@@ -335,7 +335,7 @@ class ServerRequest implements ServerRequestInterface
     /**
      * {@inheritdoc}
      */
-    public function withHeader($name, $value)
+    public function withHeader($name, $value): self
     {
         $serverRequest = $this->serverRequest->withHeader($name, $value);
         return new static($serverRequest);
@@ -344,7 +344,7 @@ class ServerRequest implements ServerRequestInterface
     /**
      * {@inheritdoc}
      */
-    public function withoutHeader($name)
+    public function withoutHeader($name): self
     {
         $serverRequest = $this->serverRequest->withoutHeader($name);
         return new static($serverRequest);
@@ -353,7 +353,7 @@ class ServerRequest implements ServerRequestInterface
     /**
      * {@inheritdoc}
      */
-    public function withMethod($method)
+    public function withMethod($method): self
     {
         $serverRequest = $this->serverRequest->withMethod($method);
         return new static($serverRequest);
@@ -362,7 +362,7 @@ class ServerRequest implements ServerRequestInterface
     /**
      * {@inheritdoc}
      */
-    public function withParsedBody($data)
+    public function withParsedBody($data): self
     {
         $serverRequest = $this->serverRequest->withParsedBody($data);
         return new static($serverRequest);
@@ -371,7 +371,7 @@ class ServerRequest implements ServerRequestInterface
     /**
      * {@inheritdoc}
      */
-    public function withProtocolVersion($version)
+    public function withProtocolVersion($version): self
     {
         $serverRequest = $this->serverRequest->withProtocolVersion($version);
         return new static($serverRequest);
@@ -380,7 +380,7 @@ class ServerRequest implements ServerRequestInterface
     /**
      * {@inheritdoc}
      */
-    public function withQueryParams(array $query)
+    public function withQueryParams(array $query): self
     {
         $serverRequest = $this->serverRequest->withQueryParams($query);
         return new static($serverRequest);
@@ -389,7 +389,7 @@ class ServerRequest implements ServerRequestInterface
     /**
      * {@inheritdoc}
      */
-    public function withRequestTarget($requestTarget)
+    public function withRequestTarget($requestTarget): self
     {
         $serverRequest = $this->serverRequest->withRequestTarget($requestTarget);
         return new static($serverRequest);
@@ -398,7 +398,7 @@ class ServerRequest implements ServerRequestInterface
     /**
      * {@inheritdoc}
      */
-    public function withUploadedFiles(array $uploadedFiles)
+    public function withUploadedFiles(array $uploadedFiles): self
     {
         $serverRequest = $this->serverRequest->withUploadedFiles($uploadedFiles);
         return new static($serverRequest);
@@ -407,7 +407,7 @@ class ServerRequest implements ServerRequestInterface
     /**
      * {@inheritdoc}
      */
-    public function withUri(UriInterface $uri, $preserveHost = false)
+    public function withUri(UriInterface $uri, $preserveHost = false): self
     {
         $serverRequest = $this->serverRequest->withUri($uri, $preserveHost);
         return new static($serverRequest);
@@ -467,7 +467,7 @@ class ServerRequest implements ServerRequestInterface
      *
      * @return mixed
      */
-    public function getCookieParam($key, $default = null)
+    public function getCookieParam(string $key, $default = null)
     {
         $cookies = $this->serverRequest->getCookieParams();
         $result = $default;
@@ -537,7 +537,7 @@ class ServerRequest implements ServerRequestInterface
      *
      * @return mixed The parameter value.
      */
-    public function getParam($key, $default = null)
+    public function getParam(string $key, $default = null)
     {
         $postParams = $this->getParsedBody();
         $getParams = $this->getQueryParams();
@@ -583,7 +583,7 @@ class ServerRequest implements ServerRequestInterface
      *
      * @return mixed
      */
-    public function getParsedBodyParam($key, $default = null)
+    public function getParsedBodyParam(string $key, $default = null)
     {
         $postParams = $this->getParsedBody();
         $result = $default;
@@ -607,7 +607,7 @@ class ServerRequest implements ServerRequestInterface
      *
      * @return mixed
      */
-    public function getQueryParam($key, $default = null)
+    public function getQueryParam(string $key, $default = null)
     {
         $getParams = $this->getQueryParams();
         $result = $default;
@@ -624,11 +624,11 @@ class ServerRequest implements ServerRequestInterface
      *
      * Note: This method is not part of the PSR-7 standard.
      *
-     * @param  string $key
-     * @param  mixed  $default
+     * @param string $key
+     * @param mixed  $default
      * @return mixed
      */
-    public function getServerParam($key, $default = null)
+    public function getServerParam(string $key, $default = null)
     {
         $serverParams = $this->serverRequest->getServerParams();
         return isset($serverParams[$key]) ? $serverParams[$key] : $default;
@@ -643,7 +643,7 @@ class ServerRequest implements ServerRequestInterface
      * @param callable $callable  A callable that returns parsed contents for media type.
      * @return static
      */
-    public function registerMediaTypeParser($mediaType, callable $callable): ServerRequestInterface
+    public function registerMediaTypeParser(string $mediaType, callable $callable): ServerRequestInterface
     {
         if ($callable instanceof Closure) {
             $callable = $callable->bindTo($this);
@@ -698,7 +698,7 @@ class ServerRequest implements ServerRequestInterface
      * @param  string $method HTTP method
      * @return bool
      */
-    public function isMethod($method): bool
+    public function isMethod(string $method): bool
     {
         return $this->serverRequest->getMethod() === $method;
     }


### PR DESCRIPTION
This PR adds type hints and fixes docblocks for `\Slim\Http\ServerRequest`.