### PR TITLE
[WIP] Response::withFile() and Response::withFileDownload()

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ script:
 - if [[ "$ANALYSIS" == 'true' ]]; then vendor/bin/phpunit --coverage-clover clover.xml ; fi
 - vendor/bin/phpunit
 - vendor/bin/phpcs
-- vendor/bin/phpstan analyse src tests
+- vendor/bin/phpstan analyse src
 
 after_success:
 - if [[ "$ANALYSIS" == 'true' ]]; then vendor/bin/php-coveralls --coverage_clover=clover.xml -v ; fi

--- a/README.md
+++ b/README.md
@@ -104,14 +104,16 @@ The decorated `ResponseInterface` provides the following additional methods:
 
 #### `Response::withFileDownload($file, $name)` ####
 Triggers the client to download the specified file.
-| Parameter            | Type                              | Description                                                                 |
-|----------------------|-----------------------------------|-----------------------------------------------------------------------------|
-| **$file**            | `string|resource|StreamInterface` | The file to send to the client                                              |
-| **$name**            | `string|null`                     | The filename for the `Content-Disposition` header. Defaults to `attachment` |
-| **$contentType**     | `bool|string`                     | Set the `Content-Type` header. Defaults to true, which attempts to detect mime type from file extension, set to false to disable. |
+
+| Parameter        | Type                              | Description                                                                                                                       |
+|------------------|-----------------------------------|-----------------------------------------------------------------------------------------------------------------------------------|
+| **$file**        | `string|resource|StreamInterface` | The file to send to the client                                                                                                    |
+| **$name**        | `string|null`                     | The filename for the `Content-Disposition` header. Defaults to `attachment`                                                       |
+| **$contentType** | `bool|string`                     | Set the `Content-Type` header. Defaults to true, which attempts to detect mime type from file extension, set to false to disable. |
 
 #### `Response::withFile($file, $contentType)` ####
 Response with file to client
+
 | Parameter            | Type                              | Description                                                                                                                       |
 |----------------------|-----------------------------------|-----------------------------------------------------------------------------------------------------------------------------------|
 | **$file**            | `string|resource|StreamInterface` | The file to send to the client                                                                                                    |

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ $response = $response->withJson(['data' => [1, 2, 3]]);
 ```
 
 
-## Decoratored Response Object Methods
+## Decorated Response Object Methods
 The decorated `ResponseInterface` provides the following additional methods:
 
 #### `Response::withJson($data, $status, $options, $depth)` ####
@@ -101,6 +101,21 @@ The decorated `ResponseInterface` provides the following additional methods:
 | **$data**   | `mixed` | The data to encode      |
 | **$status** | `int`   | The HTTP Status Code    |
 | **$depth**  | `int`   | JSON encoding max depth |
+
+#### `Response::withFileDownload($file, $name)` ####
+Triggers the client to download the specified file.
+| Parameter            | Type                              | Description                                                                 |
+|----------------------|-----------------------------------|-----------------------------------------------------------------------------|
+| **$file**            | `string|resource|StreamInterface` | The file to send to the client                                              |
+| **$name**            | `string|null`                     | The filename for the `Content-Disposition` header. Defaults to `attachment` |
+| **$contentType**     | `bool|string`                     | Set the `Content-Type` header. Defaults to true, which attempts to detect mime type from file extension, set to false to disable. |
+
+#### `Response::withFile($file, $contentType)` ####
+Response with file to client
+| Parameter            | Type                              | Description                                                                                                                       |
+|----------------------|-----------------------------------|-----------------------------------------------------------------------------------------------------------------------------------|
+| **$file**            | `string|resource|StreamInterface` | The file to send to the client                                                                                                    |
+| **$contentType**     | `bool|string`                     | Set the `Content-Type` header. Defaults to true, which attempts to detect mime type from file extension, set to false to disable. |
 
 #### `Response::withRedirect($url, $status)` ####
 | Parameter   | Type     | Description                  |
@@ -150,7 +165,7 @@ Content-Type: application/json;charset=utf-8
 ```
 
 
-## Decoratored ServerRequest Object Methods
+## Decorated ServerRequest Object Methods
 The decorated `ServerRequestInterface` provides the following additional methods:
 
 #### `ServerRequest::withAttributes($attributes)` ####

--- a/composer.json
+++ b/composer.json
@@ -28,6 +28,7 @@
     }
   ],
   "require": {
+    "ext-fileinfo": "*",
     "ext-json": "*",
     "ext-libxml": "*",
     "ext-SimpleXML": "*",

--- a/composer.json
+++ b/composer.json
@@ -65,6 +65,6 @@
     ],
     "phpunit": "php vendor/bin/phpunit --process-isolation",
     "phpcs": "php vendor/bin/phpcs",
-    "phpstan": "php -d memory_limit=-1 vendor/bin/phpstan analyse src tests"
+    "phpstan": "php -d memory_limit=-1 vendor/bin/phpstan analyse src"
   }
 }

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,7 +1,2 @@
 parameters:
   level: max
-  ignoreErrors:
-    - '#Access to an undefined property Slim\\Http\\Response::\$foo#'
-    - '#Access to an undefined property Slim\\Http\\ServerRequest::\$foo#'
-    - '#Access to an undefined property Slim\\Http\\Uri::\$foo#'
-    - '#Parameter \#1 \$port of method Slim\\Http\\Uri::withPort() expects int|null, string given#'

--- a/src/Response.php
+++ b/src/Response.php
@@ -249,12 +249,15 @@ class Response implements ResponseInterface
             $fileName = basename($file);
         }
 
-        if ($file instanceof StreamInterface && $name === null) {
-            $metaData = $file->getMetadata();
+        if ($name === null && (is_resource($file) || $file instanceof StreamInterface)) {
+            $metaData = $file instanceof StreamInterface
+                ? $file->getMetadata()
+                : stream_get_meta_data($file);
+
             if (is_array($metaData) && isset($metaData['uri'])) {
                 $uri = $metaData['uri'];
                 if ('php://' !== substr($uri, 0, 6)) {
-                    $fileName = $uri;
+                    $fileName = basename($uri);
                 }
             }
         }
@@ -268,7 +271,8 @@ class Response implements ResponseInterface
             $disposition .= "; filename*=UTF-8''" . rawurlencode($fileName);
         }
 
-        return $this->withFile($file, $contentType)
+        return $this
+            ->withFile($file, $contentType)
             ->withHeader('Content-Disposition', $disposition);
     }
 

--- a/src/Response.php
+++ b/src/Response.php
@@ -287,7 +287,10 @@ class Response implements ResponseInterface
         } elseif ($file instanceof StreamInterface) {
             $response = $response->withBody($file);
         } else {
-            throw new InvalidArgumentException('Parameter 1 of Response::withFile() must be a resource, a string or an instance of Psr\Http\Message\StreamInterface.');
+            throw new InvalidArgumentException(
+                'Parameter 1 of Response::withFile() must be a resource, a string ' .
+                'or an instance of Psr\Http\Message\StreamInterface.'
+            );
         }
 
         if ($contentType === true) {

--- a/src/Response.php
+++ b/src/Response.php
@@ -245,11 +245,11 @@ class Response implements ResponseInterface
         $disposition = 'attachment';
         $fileName = $name;
 
-        if (is_string($file)) {
+        if (is_string($file) && $name === null) {
             $fileName = basename($file);
         }
 
-        if (strlen($fileName)) {
+        if (is_string($fileName) && strlen($fileName)) {
             $disposition .= '; filename="' . urlencode($fileName) . '"';
         }
 
@@ -271,7 +271,7 @@ class Response implements ResponseInterface
      * @param string|resource|StreamInterface $file
      * @param bool|string                     $contentType
      *
-     * @return ResponseInterface
+     * @return static
      *
      * @throws RuntimeException If the file cannot be opened.
      * @throws InvalidArgumentException If the mode is invalid.

--- a/src/Response.php
+++ b/src/Response.php
@@ -260,6 +260,11 @@ class Response implements ResponseInterface
         }
 
         if (is_string($fileName) && strlen($fileName)) {
+            /*
+             * The regex used below is to ensure that the $fileName contains only
+             * characters ranging from ASCII 128-255 and ASCII 0-31 and 127 are replaced with an empty string
+             */
+            $disposition .= '; filename="' . preg_replace('/[\x00-\x1F\x7F\"]/', ' ', $fileName) . '"';
             $disposition .= "; filename*=UTF-8''" . rawurlencode($fileName);
         }
 

--- a/src/Response.php
+++ b/src/Response.php
@@ -249,8 +249,18 @@ class Response implements ResponseInterface
             $fileName = basename($file);
         }
 
+        if ($file instanceof StreamInterface && $name === null) {
+            $metaData = $file->getMetadata();
+            if (is_array($metaData) && isset($metaData['uri'])) {
+                $uri = $metaData['uri'];
+                if ('php://' !== substr($uri, 0, 6)) {
+                    $fileName = $uri;
+                }
+            }
+        }
+
         if (is_string($fileName) && strlen($fileName)) {
-            $disposition .= '; filename="' . urlencode($fileName) . '"';
+            $disposition .= "; filename*=UTF-8''" . rawurlencode($fileName);
         }
 
         return $this->withFile($file, $contentType)

--- a/tests/Assets/plain.txt
+++ b/tests/Assets/plain.txt
@@ -1,0 +1,1 @@
+Hello World

--- a/tests/ResponseTest.php
+++ b/tests/ResponseTest.php
@@ -283,7 +283,7 @@ class ResponseTest extends TestCase
             );
 
             switch ($openAs) {
-                case 'resource';
+                case 'resource':
                     $file = fopen($path, 'r');
                     break;
 
@@ -291,7 +291,7 @@ class ResponseTest extends TestCase
                     $file = $provider->getStreamFactory()->createStreamFromFile($path);
                     break;
 
-                default;
+                default:
                 case 'string':
                     $file = $path;
                     break;
@@ -366,7 +366,7 @@ class ResponseTest extends TestCase
             );
 
             switch ($openAs) {
-                case 'resource';
+                case 'resource':
                     $file = fopen($path, 'r');
                     break;
 
@@ -374,7 +374,7 @@ class ResponseTest extends TestCase
                     $file = $provider->getStreamFactory()->createStreamFromFile($path);
                     break;
 
-                default;
+                default:
                 case 'string':
                     $file = $path;
                     break;

--- a/tests/ResponseTest.php
+++ b/tests/ResponseTest.php
@@ -9,12 +9,11 @@ declare(strict_types=1);
 
 namespace Slim\Tests\Http;
 
-use Psr\Http\Message\StreamInterface;
+use InvalidArgumentException;
 use RuntimeException;
 use Slim\Http\Factory\DecoratedResponseFactory;
 use Slim\Http\Response;
 use Slim\Tests\Http\Providers\Psr17FactoryProvider;
-use Zend\Diactoros\StreamFactory;
 
 class ResponseTest extends TestCase
 {
@@ -307,6 +306,24 @@ class ResponseTest extends TestCase
             if (is_resource($file)) {
                 fclose($file);
             }
+        }
+    }
+
+    /**
+     * @expectedException InvalidArgumentException
+     */
+    public function testWithFileThrowsInvalidArgumentException()
+    {
+        foreach ($this->factoryProviders as $factoryProvider) {
+            /** @var Psr17FactoryProvider $provider */
+            $provider = new $factoryProvider();
+
+            $decoratedResponseFactory = new DecoratedResponseFactory(
+                $provider->getResponseFactory(),
+                $provider->getStreamFactory()
+            );
+
+            $decoratedResponseFactory->createResponse()->withFile(1);
         }
     }
 

--- a/tests/ResponseTest.php
+++ b/tests/ResponseTest.php
@@ -9,10 +9,12 @@ declare(strict_types=1);
 
 namespace Slim\Tests\Http;
 
+use Psr\Http\Message\StreamInterface;
 use RuntimeException;
 use Slim\Http\Factory\DecoratedResponseFactory;
 use Slim\Http\Response;
 use Slim\Tests\Http\Providers\Psr17FactoryProvider;
+use Zend\Diactoros\StreamFactory;
 
 class ResponseTest extends TestCase
 {
@@ -20,7 +22,7 @@ class ResponseTest extends TestCase
     {
         foreach ($this->factoryProviders as $factoryProvider) {
             /** @var Psr17FactoryProvider $provider */
-            $provider = new $factoryProvider;
+            $provider = new $factoryProvider();
             $decoratedResponseFactory = new DecoratedResponseFactory(
                 $provider->getResponseFactory(),
                 $provider->getStreamFactory()
@@ -37,7 +39,7 @@ class ResponseTest extends TestCase
     {
         foreach ($this->factoryProviders as $factoryProvider) {
             /** @var Psr17FactoryProvider $provider */
-            $provider = new $factoryProvider;
+            $provider = new $factoryProvider();
             $decoratedResponseFactory = new DecoratedResponseFactory(
                 $provider->getResponseFactory(),
                 $provider->getStreamFactory()
@@ -54,7 +56,7 @@ class ResponseTest extends TestCase
     {
         foreach ($this->factoryProviders as $factoryProvider) {
             /** @var Psr17FactoryProvider $provider */
-            $provider = new $factoryProvider;
+            $provider = new $factoryProvider();
             $decoratedResponseFactory = new DecoratedResponseFactory(
                 $provider->getResponseFactory(),
                 $provider->getStreamFactory()
@@ -69,7 +71,7 @@ class ResponseTest extends TestCase
     {
         foreach ($this->factoryProviders as $factoryProvider) {
             /** @var Psr17FactoryProvider $provider */
-            $provider = new $factoryProvider;
+            $provider = new $factoryProvider();
             $decoratedResponseFactory = new DecoratedResponseFactory(
                 $provider->getResponseFactory(),
                 $provider->getStreamFactory()
@@ -87,7 +89,7 @@ class ResponseTest extends TestCase
     {
         foreach ($this->factoryProviders as $factoryProvider) {
             /** @var Psr17FactoryProvider $provider */
-            $provider = new $factoryProvider;
+            $provider = new $factoryProvider();
             $decoratedResponseFactory = new DecoratedResponseFactory(
                 $provider->getResponseFactory(),
                 $provider->getStreamFactory()
@@ -102,7 +104,7 @@ class ResponseTest extends TestCase
     {
         foreach ($this->factoryProviders as $factoryProvider) {
             /** @var Psr17FactoryProvider $provider */
-            $provider = new $factoryProvider;
+            $provider = new $factoryProvider();
             $decoratedResponseFactory = new DecoratedResponseFactory(
                 $provider->getResponseFactory(),
                 $provider->getStreamFactory()
@@ -117,7 +119,7 @@ class ResponseTest extends TestCase
     {
         foreach ($this->factoryProviders as $factoryProvider) {
             /** @var Psr17FactoryProvider $provider */
-            $provider = new $factoryProvider;
+            $provider = new $factoryProvider();
             $decoratedResponseFactory = new DecoratedResponseFactory(
                 $provider->getResponseFactory(),
                 $provider->getStreamFactory()
@@ -135,7 +137,7 @@ class ResponseTest extends TestCase
     {
         foreach ($this->factoryProviders as $factoryProvider) {
             /** @var Psr17FactoryProvider $provider */
-            $provider = new $factoryProvider;
+            $provider = new $factoryProvider();
             $decoratedResponseFactory = new DecoratedResponseFactory(
                 $provider->getResponseFactory(),
                 $provider->getStreamFactory()
@@ -155,7 +157,7 @@ class ResponseTest extends TestCase
     {
         foreach ($this->factoryProviders as $factoryProvider) {
             /** @var Psr17FactoryProvider $provider */
-            $provider = new $factoryProvider;
+            $provider = new $factoryProvider();
             $decoratedResponseFactory = new DecoratedResponseFactory(
                 $provider->getResponseFactory(),
                 $provider->getStreamFactory()
@@ -172,7 +174,7 @@ class ResponseTest extends TestCase
     {
         foreach ($this->factoryProviders as $factoryProvider) {
             /** @var Psr17FactoryProvider $provider */
-            $provider = new $factoryProvider;
+            $provider = new $factoryProvider();
             $decoratedResponseFactory = new DecoratedResponseFactory(
                 $provider->getResponseFactory(),
                 $provider->getStreamFactory()
@@ -200,11 +202,201 @@ class ResponseTest extends TestCase
         }
     }
 
+    public function fileProvider()
+    {
+        return [
+            'with resource and content type specified' => [
+                'text/plain',
+                'resource',
+                'Hello World',
+                'text/plain',
+            ],
+            'with resource and content type auto-detection on' => [
+                true,
+                'resource',
+                'Hello World',
+                'application/octet-stream',
+            ],
+            'with resource and content type auto-detection off' => [
+                false,
+                'resource',
+                'Hello World',
+                '',
+            ],
+            'with string and content type specified' => [
+                'text/plain',
+                'string',
+                'Hello World',
+                'text/plain',
+            ],
+            'with string and content type auto-detection on' => [
+                true,
+                'string',
+                'Hello World',
+                'text/plain',
+            ],
+            'with string and content type auto-detection off' => [
+                false,
+                'string',
+                'Hello World',
+                '',
+            ],
+            'with stream and content type specified' => [
+                'text/plain',
+                'stream',
+                'Hello World',
+                'text/plain',
+            ],
+            'with stream and content type auto-detection on' => [
+                true,
+                'stream',
+                'Hello World',
+                'application/octet-stream',
+            ],
+            'with stream and content type auto-detection off' => [
+                false,
+                'stream',
+                'Hello World',
+                '',
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider fileProvider
+     * @param bool|string $contentType
+     * @param string      $openAs
+     * @param string      $expectedBody
+     * @param string      $expectedContentType
+     */
+    public function testWithFile($contentType, string $openAs, string $expectedBody, string $expectedContentType)
+    {
+        $path = __DIR__ . '/Assets/plain.txt';
+
+        foreach ($this->factoryProviders as $factoryProvider) {
+            /** @var Psr17FactoryProvider $provider */
+            $provider = new $factoryProvider();
+
+            $decoratedResponseFactory = new DecoratedResponseFactory(
+                $provider->getResponseFactory(),
+                $provider->getStreamFactory()
+            );
+
+            switch ($openAs) {
+                case 'resource';
+                    $file = fopen($path, 'r');
+                    break;
+
+                case 'stream':
+                    $file = $provider->getStreamFactory()->createStreamFromFile($path);
+                    break;
+
+                default;
+                case 'string':
+                    $file = $path;
+                    break;
+            }
+
+            $response = $decoratedResponseFactory
+                ->createResponse()
+                ->withFile($file, $contentType);
+
+            $this->assertEquals($expectedBody, (string) $response->getBody());
+            $this->assertEquals($expectedContentType, $response->getHeaderLine('Content-Type'));
+
+            if (is_resource($file)) {
+                fclose($file);
+            }
+        }
+    }
+
+    public function fileDownloadProvider()
+    {
+        return [
+            'with resource and file name specified' => [
+                'plain.txt',
+                'resource',
+                'attachment; filename="plain.txt"; filename*=UTF-8\'\'plain.txt',
+            ],
+            'with resource and file name not specified' => [
+                null,
+                'resource',
+                'attachment; filename="plain.txt"; filename*=UTF-8\'\'plain.txt',
+            ],
+            'with string and file name specified' => [
+                'plain.txt',
+                'string',
+                'attachment; filename="plain.txt"; filename*=UTF-8\'\'plain.txt',
+            ],
+            'with string and file name not specified' => [
+                null,
+                'string',
+                'attachment; filename="plain.txt"; filename*=UTF-8\'\'plain.txt',
+            ],
+            'with stream and file name specified' => [
+                'plain.txt',
+                'stream',
+                'attachment; filename="plain.txt"; filename*=UTF-8\'\'plain.txt',
+            ],
+            'with stream and file name not specified' => [
+                null,
+                'stream',
+                'attachment; filename="plain.txt"; filename*=UTF-8\'\'plain.txt',
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider fileDownloadProvider
+     * @param string|null $name
+     * @param string      $openAs
+     * @param string      $expectedContentDisposition
+     */
+    public function testWithFileDownload(?string $name, string $openAs, string $expectedContentDisposition)
+    {
+        $path = __DIR__ . '/Assets/plain.txt';
+
+        foreach ($this->factoryProviders as $factoryProvider) {
+            /** @var Psr17FactoryProvider $provider */
+            $provider = new $factoryProvider();
+
+            $decoratedResponseFactory = new DecoratedResponseFactory(
+                $provider->getResponseFactory(),
+                $provider->getStreamFactory()
+            );
+
+            switch ($openAs) {
+                case 'resource';
+                    $file = fopen($path, 'r');
+                    break;
+
+                case 'stream':
+                    $file = $provider->getStreamFactory()->createStreamFromFile($path);
+                    break;
+
+                default;
+                case 'string':
+                    $file = $path;
+                    break;
+            }
+
+            $response = $decoratedResponseFactory
+                ->createResponse()
+                ->withFileDownload($file, $name);
+
+            $this->assertEquals($expectedContentDisposition, $response->getHeaderLine('Content-Disposition'));
+
+            if (is_resource($file)) {
+                fclose($file);
+            }
+        }
+    }
+
     public function testIsEmpty()
     {
         foreach ($this->factoryProviders as $factoryProvider) {
             /** @var Psr17FactoryProvider $provider */
-            $provider = new $factoryProvider;
+            $provider = new $factoryProvider();
             $decoratedResponseFactory = new DecoratedResponseFactory(
                 $provider->getResponseFactory(),
                 $provider->getStreamFactory()
@@ -220,7 +412,7 @@ class ResponseTest extends TestCase
     {
         foreach ($this->factoryProviders as $factoryProvider) {
             /** @var Psr17FactoryProvider $provider */
-            $provider = new $factoryProvider;
+            $provider = new $factoryProvider();
             $decoratedResponseFactory = new DecoratedResponseFactory(
                 $provider->getResponseFactory(),
                 $provider->getStreamFactory()
@@ -236,7 +428,7 @@ class ResponseTest extends TestCase
     {
         foreach ($this->factoryProviders as $factoryProvider) {
             /** @var Psr17FactoryProvider $provider */
-            $provider = new $factoryProvider;
+            $provider = new $factoryProvider();
             $decoratedResponseFactory = new DecoratedResponseFactory(
                 $provider->getResponseFactory(),
                 $provider->getStreamFactory()
@@ -252,7 +444,7 @@ class ResponseTest extends TestCase
     {
         foreach ($this->factoryProviders as $factoryProvider) {
             /** @var Psr17FactoryProvider $provider */
-            $provider = new $factoryProvider;
+            $provider = new $factoryProvider();
             $decoratedResponseFactory = new DecoratedResponseFactory(
                 $provider->getResponseFactory(),
                 $provider->getStreamFactory()
@@ -267,7 +459,7 @@ class ResponseTest extends TestCase
     {
         foreach ($this->factoryProviders as $factoryProvider) {
             /** @var Psr17FactoryProvider $provider */
-            $provider = new $factoryProvider;
+            $provider = new $factoryProvider();
             $decoratedResponseFactory = new DecoratedResponseFactory(
                 $provider->getResponseFactory(),
                 $provider->getStreamFactory()
@@ -282,7 +474,7 @@ class ResponseTest extends TestCase
     {
         foreach ($this->factoryProviders as $factoryProvider) {
             /** @var Psr17FactoryProvider $provider */
-            $provider = new $factoryProvider;
+            $provider = new $factoryProvider();
             $decoratedResponseFactory = new DecoratedResponseFactory(
                 $provider->getResponseFactory(),
                 $provider->getStreamFactory()
@@ -297,7 +489,7 @@ class ResponseTest extends TestCase
     {
         foreach ($this->factoryProviders as $factoryProvider) {
             /** @var Psr17FactoryProvider $provider */
-            $provider = new $factoryProvider;
+            $provider = new $factoryProvider();
             $decoratedResponseFactory = new DecoratedResponseFactory(
                 $provider->getResponseFactory(),
                 $provider->getStreamFactory()
@@ -312,7 +504,7 @@ class ResponseTest extends TestCase
     {
         foreach ($this->factoryProviders as $factoryProvider) {
             /** @var Psr17FactoryProvider $provider */
-            $provider = new $factoryProvider;
+            $provider = new $factoryProvider();
             $decoratedResponseFactory = new DecoratedResponseFactory(
                 $provider->getResponseFactory(),
                 $provider->getStreamFactory()
@@ -327,7 +519,7 @@ class ResponseTest extends TestCase
     {
         foreach ($this->factoryProviders as $factoryProvider) {
             /** @var Psr17FactoryProvider $provider */
-            $provider = new $factoryProvider;
+            $provider = new $factoryProvider();
             $decoratedResponseFactory = new DecoratedResponseFactory(
                 $provider->getResponseFactory(),
                 $provider->getStreamFactory()
@@ -342,7 +534,7 @@ class ResponseTest extends TestCase
     {
         foreach ($this->factoryProviders as $factoryProvider) {
             /** @var Psr17FactoryProvider $provider */
-            $provider = new $factoryProvider;
+            $provider = new $factoryProvider();
             $decoratedResponseFactory = new DecoratedResponseFactory(
                 $provider->getResponseFactory(),
                 $provider->getStreamFactory()
@@ -364,7 +556,7 @@ class ResponseTest extends TestCase
 
         foreach ($this->factoryProviders as $factoryProvider) {
             /** @var Psr17FactoryProvider $provider */
-            $provider = new $factoryProvider;
+            $provider = new $factoryProvider();
             $decoratedResponseFactory = new DecoratedResponseFactory(
                 $provider->getResponseFactory(),
                 $provider->getStreamFactory()
@@ -386,7 +578,7 @@ class ResponseTest extends TestCase
 
         foreach ($this->factoryProviders as $factoryProvider) {
             /** @var Psr17FactoryProvider $provider */
-            $provider = new $factoryProvider;
+            $provider = new $factoryProvider();
             $decoratedResponseFactory = new DecoratedResponseFactory(
                 $provider->getResponseFactory(),
                 $provider->getStreamFactory()
@@ -437,7 +629,7 @@ class ResponseTest extends TestCase
 
         foreach ($this->factoryProviders as $factoryProvider) {
             /** @var Psr17FactoryProvider $provider */
-            $provider = new $factoryProvider;
+            $provider = new $factoryProvider();
             $decoratedResponseFactory = new DecoratedResponseFactory(
                 $provider->getResponseFactory(),
                 $provider->getStreamFactory()

--- a/tests/ServerRequestTest.php
+++ b/tests/ServerRequestTest.php
@@ -20,7 +20,7 @@ class ServerRequestTest extends TestCase
     {
         foreach ($this->factoryProviders as $factoryProvider) {
             /** @var Psr17FactoryProvider $provider */
-            $provider = new $factoryProvider;
+            $provider = new $factoryProvider();
             $decoratedServerRequestFactory = new DecoratedServerRequestFactory($provider->getServerRequestFactory());
 
             $request = $decoratedServerRequestFactory->createServerRequest('GET', '/');
@@ -34,7 +34,7 @@ class ServerRequestTest extends TestCase
     {
         foreach ($this->factoryProviders as $factoryProvider) {
             /** @var Psr17FactoryProvider $provider */
-            $provider = new $factoryProvider;
+            $provider = new $factoryProvider();
             $decoratedServerRequestFactory = new DecoratedServerRequestFactory($provider->getServerRequestFactory());
 
             $request = $decoratedServerRequestFactory->createServerRequest('GET', 'http://example.com');
@@ -46,7 +46,7 @@ class ServerRequestTest extends TestCase
     {
         foreach ($this->factoryProviders as $factoryProvider) {
             /** @var Psr17FactoryProvider $provider */
-            $provider = new $factoryProvider;
+            $provider = new $factoryProvider();
             $decoratedServerRequestFactory = new DecoratedServerRequestFactory($provider->getServerRequestFactory());
 
             $request = $decoratedServerRequestFactory->createServerRequest('GET', '/');
@@ -58,7 +58,7 @@ class ServerRequestTest extends TestCase
     {
         foreach ($this->factoryProviders as $factoryProvider) {
             /** @var Psr17FactoryProvider $provider */
-            $provider = new $factoryProvider;
+            $provider = new $factoryProvider();
             $decoratedServerRequestFactory = new DecoratedServerRequestFactory($provider->getServerRequestFactory());
 
             $request = $decoratedServerRequestFactory->createServerRequest('GET', '/');
@@ -71,7 +71,7 @@ class ServerRequestTest extends TestCase
     {
         foreach ($this->factoryProviders as $factoryProvider) {
             /** @var Psr17FactoryProvider $provider */
-            $provider = new $factoryProvider;
+            $provider = new $factoryProvider();
             $decoratedServerRequestFactory = new DecoratedServerRequestFactory($provider->getServerRequestFactory());
 
             $request = $decoratedServerRequestFactory->createServerRequest('GET', '/');
@@ -84,7 +84,7 @@ class ServerRequestTest extends TestCase
     {
         foreach ($this->factoryProviders as $factoryProvider) {
             /** @var Psr17FactoryProvider $provider */
-            $provider = new $factoryProvider;
+            $provider = new $factoryProvider();
             $decoratedServerRequestFactory = new DecoratedServerRequestFactory($provider->getServerRequestFactory());
 
             $request = $decoratedServerRequestFactory->createServerRequest('GET', '/');
@@ -100,7 +100,7 @@ class ServerRequestTest extends TestCase
     {
         foreach ($this->factoryProviders as $factoryProvider) {
             /** @var Psr17FactoryProvider $provider */
-            $provider = new $factoryProvider;
+            $provider = new $factoryProvider();
             $decoratedServerRequestFactory = new DecoratedServerRequestFactory($provider->getServerRequestFactory());
 
             $request = $decoratedServerRequestFactory->createServerRequest('GET', '/');
@@ -112,7 +112,7 @@ class ServerRequestTest extends TestCase
     {
         foreach ($this->factoryProviders as $factoryProvider) {
             /** @var Psr17FactoryProvider $provider */
-            $provider = new $factoryProvider;
+            $provider = new $factoryProvider();
             $decoratedServerRequestFactory = new DecoratedServerRequestFactory($provider->getServerRequestFactory());
 
             $request = $decoratedServerRequestFactory->createServerRequest('GET', '/');
@@ -124,7 +124,7 @@ class ServerRequestTest extends TestCase
     {
         foreach ($this->factoryProviders as $factoryProvider) {
             /** @var Psr17FactoryProvider $provider */
-            $provider = new $factoryProvider;
+            $provider = new $factoryProvider();
             $decoratedServerRequestFactory = new DecoratedServerRequestFactory($provider->getServerRequestFactory());
 
             $request = $decoratedServerRequestFactory->createServerRequest('POST', '/');
@@ -136,7 +136,7 @@ class ServerRequestTest extends TestCase
     {
         foreach ($this->factoryProviders as $factoryProvider) {
             /** @var Psr17FactoryProvider $provider */
-            $provider = new $factoryProvider;
+            $provider = new $factoryProvider();
             $decoratedServerRequestFactory = new DecoratedServerRequestFactory($provider->getServerRequestFactory());
 
             $request = $decoratedServerRequestFactory->createServerRequest('PUT', '/');
@@ -148,7 +148,7 @@ class ServerRequestTest extends TestCase
     {
         foreach ($this->factoryProviders as $factoryProvider) {
             /** @var Psr17FactoryProvider $provider */
-            $provider = new $factoryProvider;
+            $provider = new $factoryProvider();
             $decoratedServerRequestFactory = new DecoratedServerRequestFactory($provider->getServerRequestFactory());
 
             $request = $decoratedServerRequestFactory->createServerRequest('PATCH', '/');
@@ -160,7 +160,7 @@ class ServerRequestTest extends TestCase
     {
         foreach ($this->factoryProviders as $factoryProvider) {
             /** @var Psr17FactoryProvider $provider */
-            $provider = new $factoryProvider;
+            $provider = new $factoryProvider();
             $decoratedServerRequestFactory = new DecoratedServerRequestFactory($provider->getServerRequestFactory());
 
             $request = $decoratedServerRequestFactory->createServerRequest('DELETE', '/');
@@ -172,7 +172,7 @@ class ServerRequestTest extends TestCase
     {
         foreach ($this->factoryProviders as $factoryProvider) {
             /** @var Psr17FactoryProvider $provider */
-            $provider = new $factoryProvider;
+            $provider = new $factoryProvider();
             $decoratedServerRequestFactory = new DecoratedServerRequestFactory($provider->getServerRequestFactory());
 
             $request = $decoratedServerRequestFactory->createServerRequest('HEAD', '/');
@@ -184,7 +184,7 @@ class ServerRequestTest extends TestCase
     {
         foreach ($this->factoryProviders as $factoryProvider) {
             /** @var Psr17FactoryProvider $provider */
-            $provider = new $factoryProvider;
+            $provider = new $factoryProvider();
             $decoratedServerRequestFactory = new DecoratedServerRequestFactory($provider->getServerRequestFactory());
 
             $request = $decoratedServerRequestFactory->createServerRequest('OPTIONS', '/');
@@ -196,7 +196,7 @@ class ServerRequestTest extends TestCase
     {
         foreach ($this->factoryProviders as $factoryProvider) {
             /** @var Psr17FactoryProvider $provider */
-            $provider = new $factoryProvider;
+            $provider = new $factoryProvider();
             $decoratedServerRequestFactory = new DecoratedServerRequestFactory($provider->getServerRequestFactory());
 
             $request = $decoratedServerRequestFactory->createServerRequest('GET', '/');
@@ -212,7 +212,7 @@ class ServerRequestTest extends TestCase
     {
         foreach ($this->factoryProviders as $factoryProvider) {
             /** @var Psr17FactoryProvider $provider */
-            $provider = new $factoryProvider;
+            $provider = new $factoryProvider();
             $decoratedServerRequestFactory = new DecoratedServerRequestFactory($provider->getServerRequestFactory());
 
             $request = $decoratedServerRequestFactory->createServerRequest('GET', 'https://google.com/foo/bar?abc=123');
@@ -224,7 +224,7 @@ class ServerRequestTest extends TestCase
     {
         foreach ($this->factoryProviders as $factoryProvider) {
             /** @var Psr17FactoryProvider $provider */
-            $provider = new $factoryProvider;
+            $provider = new $factoryProvider();
             $decoratedServerRequestFactory = new DecoratedServerRequestFactory($provider->getServerRequestFactory());
 
             $request = $decoratedServerRequestFactory->createServerRequest('GET', 'https://google.com/foo/bar?abc=123');
@@ -238,7 +238,7 @@ class ServerRequestTest extends TestCase
     {
         foreach ($this->factoryProviders as $factoryProvider) {
             /** @var Psr17FactoryProvider $provider */
-            $provider = new $factoryProvider;
+            $provider = new $factoryProvider();
             $decoratedServerRequestFactory = new DecoratedServerRequestFactory($provider->getServerRequestFactory());
 
             $request = $decoratedServerRequestFactory->createServerRequest('GET', 'https://google.com');
@@ -250,7 +250,7 @@ class ServerRequestTest extends TestCase
     {
         foreach ($this->factoryProviders as $factoryProvider) {
             /** @var Psr17FactoryProvider $provider */
-            $provider = new $factoryProvider;
+            $provider = new $factoryProvider();
             $decoratedServerRequestFactory = new DecoratedServerRequestFactory($provider->getServerRequestFactory());
 
             $uriFactory = $provider->getUriFactory();
@@ -267,7 +267,7 @@ class ServerRequestTest extends TestCase
     {
         foreach ($this->factoryProviders as $factoryProvider) {
             /** @var Psr17FactoryProvider $provider */
-            $provider = new $factoryProvider;
+            $provider = new $factoryProvider();
             $decoratedServerRequestFactory = new DecoratedServerRequestFactory($provider->getServerRequestFactory());
 
             $request = $decoratedServerRequestFactory->createServerRequest('GET', 'https://google.com');
@@ -281,7 +281,7 @@ class ServerRequestTest extends TestCase
     {
         foreach ($this->factoryProviders as $factoryProvider) {
             /** @var Psr17FactoryProvider $provider */
-            $provider = new $factoryProvider;
+            $provider = new $factoryProvider();
             $decoratedServerRequestFactory = new DecoratedServerRequestFactory($provider->getServerRequestFactory());
 
             $request = $decoratedServerRequestFactory->createServerRequest('GET', 'https://google.com');
@@ -293,7 +293,7 @@ class ServerRequestTest extends TestCase
     {
         foreach ($this->factoryProviders as $factoryProvider) {
             /** @var Psr17FactoryProvider $provider */
-            $provider = new $factoryProvider;
+            $provider = new $factoryProvider();
             $decoratedServerRequestFactory = new DecoratedServerRequestFactory($provider->getServerRequestFactory());
 
             $request = $decoratedServerRequestFactory->createServerRequest('GET', 'https://google.com');
@@ -307,7 +307,7 @@ class ServerRequestTest extends TestCase
     {
         foreach ($this->factoryProviders as $factoryProvider) {
             /** @var Psr17FactoryProvider $provider */
-            $provider = new $factoryProvider;
+            $provider = new $factoryProvider();
             $decoratedServerRequestFactory = new DecoratedServerRequestFactory($provider->getServerRequestFactory());
 
             $request = $decoratedServerRequestFactory->createServerRequest('GET', 'https://google.com');
@@ -319,7 +319,7 @@ class ServerRequestTest extends TestCase
     {
         foreach ($this->factoryProviders as $factoryProvider) {
             /** @var Psr17FactoryProvider $provider */
-            $provider = new $factoryProvider;
+            $provider = new $factoryProvider();
             $decoratedServerRequestFactory = new DecoratedServerRequestFactory($provider->getServerRequestFactory());
 
             $request = $decoratedServerRequestFactory->createServerRequest('GET', 'https://google.com');
@@ -333,7 +333,7 @@ class ServerRequestTest extends TestCase
     {
         foreach ($this->factoryProviders as $factoryProvider) {
             /** @var Psr17FactoryProvider $provider */
-            $provider = new $factoryProvider;
+            $provider = new $factoryProvider();
             $decoratedServerRequestFactory = new DecoratedServerRequestFactory($provider->getServerRequestFactory());
 
             $request = $decoratedServerRequestFactory->createServerRequest('GET', 'https://google.com');
@@ -347,7 +347,7 @@ class ServerRequestTest extends TestCase
     {
         foreach ($this->factoryProviders as $factoryProvider) {
             /** @var Psr17FactoryProvider $provider */
-            $provider = new $factoryProvider;
+            $provider = new $factoryProvider();
             $decoratedServerRequestFactory = new DecoratedServerRequestFactory($provider->getServerRequestFactory());
 
             $request = $decoratedServerRequestFactory->createServerRequest('GET', 'https://google.com');
@@ -359,7 +359,7 @@ class ServerRequestTest extends TestCase
     {
         foreach ($this->factoryProviders as $factoryProvider) {
             /** @var Psr17FactoryProvider $provider */
-            $provider = new $factoryProvider;
+            $provider = new $factoryProvider();
             $decoratedServerRequestFactory = new DecoratedServerRequestFactory($provider->getServerRequestFactory());
 
             $request = $decoratedServerRequestFactory->createServerRequest('GET', 'https://google.com');
@@ -373,7 +373,7 @@ class ServerRequestTest extends TestCase
     {
         foreach ($this->factoryProviders as $factoryProvider) {
             /** @var Psr17FactoryProvider $provider */
-            $provider = new $factoryProvider;
+            $provider = new $factoryProvider();
             $decoratedServerRequestFactory = new DecoratedServerRequestFactory($provider->getServerRequestFactory());
 
             $request = $decoratedServerRequestFactory->createServerRequest('GET', 'https://google.com');
@@ -387,7 +387,7 @@ class ServerRequestTest extends TestCase
     {
         foreach ($this->factoryProviders as $factoryProvider) {
             /** @var Psr17FactoryProvider $provider */
-            $provider = new $factoryProvider;
+            $provider = new $factoryProvider();
             $decoratedServerRequestFactory = new DecoratedServerRequestFactory($provider->getServerRequestFactory());
 
             $request = $decoratedServerRequestFactory->createServerRequest('GET', 'https://google.com');
@@ -399,7 +399,7 @@ class ServerRequestTest extends TestCase
     {
         foreach ($this->factoryProviders as $factoryProvider) {
             /** @var Psr17FactoryProvider $provider */
-            $provider = new $factoryProvider;
+            $provider = new $factoryProvider();
             $decoratedServerRequestFactory = new DecoratedServerRequestFactory($provider->getServerRequestFactory());
 
             $request = $decoratedServerRequestFactory->createServerRequest('GET', 'https://google.com');
@@ -413,7 +413,7 @@ class ServerRequestTest extends TestCase
     {
         foreach ($this->factoryProviders as $factoryProvider) {
             /** @var Psr17FactoryProvider $provider */
-            $provider = new $factoryProvider;
+            $provider = new $factoryProvider();
             $decoratedServerRequestFactory = new DecoratedServerRequestFactory($provider->getServerRequestFactory());
 
             $request = $decoratedServerRequestFactory->createServerRequest('GET', 'https://google.com');
@@ -426,7 +426,7 @@ class ServerRequestTest extends TestCase
     {
         foreach ($this->factoryProviders as $factoryProvider) {
             /** @var Psr17FactoryProvider $provider */
-            $provider = new $factoryProvider;
+            $provider = new $factoryProvider();
             $decoratedServerRequestFactory = new DecoratedServerRequestFactory($provider->getServerRequestFactory());
 
             $request = $decoratedServerRequestFactory->createServerRequest('GET', 'https://google.com');
@@ -440,7 +440,7 @@ class ServerRequestTest extends TestCase
     {
         foreach ($this->factoryProviders as $factoryProvider) {
             /** @var Psr17FactoryProvider $provider */
-            $provider = new $factoryProvider;
+            $provider = new $factoryProvider();
             $decoratedServerRequestFactory = new DecoratedServerRequestFactory($provider->getServerRequestFactory());
 
             $request = $decoratedServerRequestFactory->createServerRequest('GET', 'https://google.com');
@@ -452,7 +452,7 @@ class ServerRequestTest extends TestCase
     {
         foreach ($this->factoryProviders as $factoryProvider) {
             /** @var Psr17FactoryProvider $provider */
-            $provider = new $factoryProvider;
+            $provider = new $factoryProvider();
             $decoratedServerRequestFactory = new DecoratedServerRequestFactory($provider->getServerRequestFactory());
 
             $request = $decoratedServerRequestFactory->createServerRequest('GET', 'https://google.com');
@@ -466,7 +466,7 @@ class ServerRequestTest extends TestCase
     {
         foreach ($this->factoryProviders as $factoryProvider) {
             /** @var Psr17FactoryProvider $provider */
-            $provider = new $factoryProvider;
+            $provider = new $factoryProvider();
             $decoratedServerRequestFactory = new DecoratedServerRequestFactory($provider->getServerRequestFactory());
 
             $request = $decoratedServerRequestFactory->createServerRequest('GET', 'https://google.com');
@@ -480,7 +480,7 @@ class ServerRequestTest extends TestCase
     {
         foreach ($this->factoryProviders as $factoryProvider) {
             /** @var Psr17FactoryProvider $provider */
-            $provider = new $factoryProvider;
+            $provider = new $factoryProvider();
             $decoratedServerRequestFactory = new DecoratedServerRequestFactory($provider->getServerRequestFactory());
 
             $request = $decoratedServerRequestFactory->createServerRequest('GET', 'https://google.com');
@@ -494,7 +494,7 @@ class ServerRequestTest extends TestCase
     {
         foreach ($this->factoryProviders as $factoryProvider) {
             /** @var Psr17FactoryProvider $provider */
-            $provider = new $factoryProvider;
+            $provider = new $factoryProvider();
             $decoratedServerRequestFactory = new DecoratedServerRequestFactory($provider->getServerRequestFactory());
 
             $request = $decoratedServerRequestFactory->createServerRequest('GET', 'https://google.com');
@@ -508,7 +508,7 @@ class ServerRequestTest extends TestCase
     {
         foreach ($this->factoryProviders as $factoryProvider) {
             /** @var Psr17FactoryProvider $provider */
-            $provider = new $factoryProvider;
+            $provider = new $factoryProvider();
             $decoratedServerRequestFactory = new DecoratedServerRequestFactory($provider->getServerRequestFactory());
 
             $request = $decoratedServerRequestFactory->createServerRequest('GET', 'https://google.com');
@@ -524,7 +524,7 @@ class ServerRequestTest extends TestCase
     {
         foreach ($this->factoryProviders as $factoryProvider) {
             /** @var Psr17FactoryProvider $provider */
-            $provider = new $factoryProvider;
+            $provider = new $factoryProvider();
             $decoratedServerRequestFactory = new DecoratedServerRequestFactory($provider->getServerRequestFactory());
 
             $streamFactory = $provider->getStreamFactory();
@@ -545,7 +545,7 @@ class ServerRequestTest extends TestCase
     {
         foreach ($this->factoryProviders as $factoryProvider) {
             /** @var Psr17FactoryProvider $provider */
-            $provider = new $factoryProvider;
+            $provider = new $factoryProvider();
             $decoratedServerRequestFactory = new DecoratedServerRequestFactory($provider->getServerRequestFactory());
 
             $serverParams = ['HTTP_AUTHORIZATION' => 'test'];
@@ -559,7 +559,7 @@ class ServerRequestTest extends TestCase
     {
         foreach ($this->factoryProviders as $factoryProvider) {
             /** @var Psr17FactoryProvider $provider */
-            $provider = new $factoryProvider;
+            $provider = new $factoryProvider();
             $decoratedServerRequestFactory = new DecoratedServerRequestFactory($provider->getServerRequestFactory());
 
             $request = $decoratedServerRequestFactory->createServerRequest('GET', 'https://google.com');
@@ -571,7 +571,7 @@ class ServerRequestTest extends TestCase
     {
         foreach ($this->factoryProviders as $factoryProvider) {
             /** @var Psr17FactoryProvider $provider */
-            $provider = new $factoryProvider;
+            $provider = new $factoryProvider();
             $decoratedServerRequestFactory = new DecoratedServerRequestFactory($provider->getServerRequestFactory());
 
             $serverParams = ['HTTP_AUTHORIZATION' => 'test'];
@@ -585,7 +585,7 @@ class ServerRequestTest extends TestCase
     {
         foreach ($this->factoryProviders as $factoryProvider) {
             /** @var Psr17FactoryProvider $provider */
-            $provider = new $factoryProvider;
+            $provider = new $factoryProvider();
             $decoratedServerRequestFactory = new DecoratedServerRequestFactory($provider->getServerRequestFactory());
 
             $request = $decoratedServerRequestFactory->createServerRequest('GET', 'https://google.com');
@@ -599,7 +599,7 @@ class ServerRequestTest extends TestCase
     {
         foreach ($this->factoryProviders as $factoryProvider) {
             /** @var Psr17FactoryProvider $provider */
-            $provider = new $factoryProvider;
+            $provider = new $factoryProvider();
             $decoratedServerRequestFactory = new DecoratedServerRequestFactory($provider->getServerRequestFactory());
 
             $request = $decoratedServerRequestFactory->createServerRequest('GET', 'https://google.com');
@@ -615,7 +615,7 @@ class ServerRequestTest extends TestCase
     {
         foreach ($this->factoryProviders as $factoryProvider) {
             /** @var Psr17FactoryProvider $provider */
-            $provider = new $factoryProvider;
+            $provider = new $factoryProvider();
             $decoratedServerRequestFactory = new DecoratedServerRequestFactory($provider->getServerRequestFactory());
 
             $request = $decoratedServerRequestFactory->createServerRequest('GET', 'https://google.com');
@@ -630,7 +630,7 @@ class ServerRequestTest extends TestCase
     {
         foreach ($this->factoryProviders as $factoryProvider) {
             /** @var Psr17FactoryProvider $provider */
-            $provider = new $factoryProvider;
+            $provider = new $factoryProvider();
             $decoratedServerRequestFactory = new DecoratedServerRequestFactory($provider->getServerRequestFactory());
 
             $request = $decoratedServerRequestFactory->createServerRequest('GET', 'https://google.com');
@@ -644,7 +644,7 @@ class ServerRequestTest extends TestCase
     {
         foreach ($this->factoryProviders as $factoryProvider) {
             /** @var Psr17FactoryProvider $provider */
-            $provider = new $factoryProvider;
+            $provider = new $factoryProvider();
             $decoratedServerRequestFactory = new DecoratedServerRequestFactory($provider->getServerRequestFactory());
 
             $request = $decoratedServerRequestFactory->createServerRequest('GET', 'https://google.com');
@@ -659,7 +659,7 @@ class ServerRequestTest extends TestCase
     {
         foreach ($this->factoryProviders as $factoryProvider) {
             /** @var Psr17FactoryProvider $provider */
-            $provider = new $factoryProvider;
+            $provider = new $factoryProvider();
             $decoratedServerRequestFactory = new DecoratedServerRequestFactory($provider->getServerRequestFactory());
 
             $request = $decoratedServerRequestFactory->createServerRequest('POST', 'https://google.com');
@@ -673,7 +673,7 @@ class ServerRequestTest extends TestCase
     {
         foreach ($this->factoryProviders as $factoryProvider) {
             /** @var Psr17FactoryProvider $provider */
-            $provider = new $factoryProvider;
+            $provider = new $factoryProvider();
             $decoratedServerRequestFactory = new DecoratedServerRequestFactory($provider->getServerRequestFactory());
 
             $request = $decoratedServerRequestFactory->createServerRequest('POST', 'https://google.com');
@@ -688,7 +688,7 @@ class ServerRequestTest extends TestCase
     {
         foreach ($this->factoryProviders as $factoryProvider) {
             /** @var Psr17FactoryProvider $provider */
-            $provider = new $factoryProvider;
+            $provider = new $factoryProvider();
             $decoratedServerRequestFactory = new DecoratedServerRequestFactory($provider->getServerRequestFactory());
 
             $streamFactory = $provider->getStreamFactory();
@@ -707,7 +707,7 @@ class ServerRequestTest extends TestCase
     {
         foreach ($this->factoryProviders as $factoryProvider) {
             /** @var Psr17FactoryProvider $provider */
-            $provider = new $factoryProvider;
+            $provider = new $factoryProvider();
             $decoratedServerRequestFactory = new DecoratedServerRequestFactory($provider->getServerRequestFactory());
 
             $streamFactory = $provider->getStreamFactory();
@@ -726,7 +726,7 @@ class ServerRequestTest extends TestCase
     {
         foreach ($this->factoryProviders as $factoryProvider) {
             /** @var Psr17FactoryProvider $provider */
-            $provider = new $factoryProvider;
+            $provider = new $factoryProvider();
             $decoratedServerRequestFactory = new DecoratedServerRequestFactory($provider->getServerRequestFactory());
 
             $streamFactory = $provider->getStreamFactory();
@@ -745,7 +745,7 @@ class ServerRequestTest extends TestCase
     {
         foreach ($this->factoryProviders as $factoryProvider) {
             /** @var Psr17FactoryProvider $provider */
-            $provider = new $factoryProvider;
+            $provider = new $factoryProvider();
             $decoratedServerRequestFactory = new DecoratedServerRequestFactory($provider->getServerRequestFactory());
 
             $streamFactory = $provider->getStreamFactory();
@@ -764,7 +764,7 @@ class ServerRequestTest extends TestCase
     {
         foreach ($this->factoryProviders as $factoryProvider) {
             /** @var Psr17FactoryProvider $provider */
-            $provider = new $factoryProvider;
+            $provider = new $factoryProvider();
             $decoratedServerRequestFactory = new DecoratedServerRequestFactory($provider->getServerRequestFactory());
 
             $streamFactory = $provider->getStreamFactory();
@@ -783,7 +783,7 @@ class ServerRequestTest extends TestCase
     {
         foreach ($this->factoryProviders as $factoryProvider) {
             /** @var Psr17FactoryProvider $provider */
-            $provider = new $factoryProvider;
+            $provider = new $factoryProvider();
             $decoratedServerRequestFactory = new DecoratedServerRequestFactory($provider->getServerRequestFactory());
 
             $streamFactory = $provider->getStreamFactory();
@@ -806,7 +806,7 @@ class ServerRequestTest extends TestCase
     {
         foreach ($this->factoryProviders as $factoryProvider) {
             /** @var Psr17FactoryProvider $provider */
-            $provider = new $factoryProvider;
+            $provider = new $factoryProvider();
             $decoratedServerRequestFactory = new DecoratedServerRequestFactory($provider->getServerRequestFactory());
 
             $streamFactory = $provider->getStreamFactory();
@@ -827,7 +827,7 @@ class ServerRequestTest extends TestCase
     {
         foreach ($this->factoryProviders as $factoryProvider) {
             /** @var Psr17FactoryProvider $provider */
-            $provider = new $factoryProvider;
+            $provider = new $factoryProvider();
             $decoratedServerRequestFactory = new DecoratedServerRequestFactory($provider->getServerRequestFactory());
 
             $streamFactory = $provider->getStreamFactory();
@@ -848,7 +848,7 @@ class ServerRequestTest extends TestCase
     {
         foreach ($this->factoryProviders as $factoryProvider) {
             /** @var Psr17FactoryProvider $provider */
-            $provider = new $factoryProvider;
+            $provider = new $factoryProvider();
             $decoratedServerRequestFactory = new DecoratedServerRequestFactory($provider->getServerRequestFactory());
 
             $streamFactory = $provider->getStreamFactory();
@@ -872,7 +872,7 @@ class ServerRequestTest extends TestCase
     {
         foreach ($this->factoryProviders as $factoryProvider) {
             /** @var Psr17FactoryProvider $provider */
-            $provider = new $factoryProvider;
+            $provider = new $factoryProvider();
             $decoratedServerRequestFactory = new DecoratedServerRequestFactory($provider->getServerRequestFactory());
 
             $streamFactory = $provider->getStreamFactory();
@@ -894,7 +894,7 @@ class ServerRequestTest extends TestCase
     {
         foreach ($this->factoryProviders as $factoryProvider) {
             /** @var Psr17FactoryProvider $provider */
-            $provider = new $factoryProvider;
+            $provider = new $factoryProvider();
             $decoratedServerRequestFactory = new DecoratedServerRequestFactory($provider->getServerRequestFactory());
 
             $streamFactory = $provider->getStreamFactory();
@@ -913,7 +913,7 @@ class ServerRequestTest extends TestCase
     {
         foreach ($this->factoryProviders as $factoryProvider) {
             /** @var Psr17FactoryProvider $provider */
-            $provider = new $factoryProvider;
+            $provider = new $factoryProvider();
             $decoratedServerRequestFactory = new DecoratedServerRequestFactory($provider->getServerRequestFactory());
 
             $request = $decoratedServerRequestFactory->createServerRequest('POST', 'https://google.com');
@@ -932,7 +932,7 @@ class ServerRequestTest extends TestCase
     {
         foreach ($this->factoryProviders as $factoryProvider) {
             /** @var Psr17FactoryProvider $provider */
-            $provider = new $factoryProvider;
+            $provider = new $factoryProvider();
             $decoratedServerRequestFactory = new DecoratedServerRequestFactory($provider->getServerRequestFactory());
 
             $streamFactory = $provider->getStreamFactory();
@@ -955,7 +955,7 @@ class ServerRequestTest extends TestCase
     {
         foreach ($this->factoryProviders as $factoryProvider) {
             /** @var Psr17FactoryProvider $provider */
-            $provider = new $factoryProvider;
+            $provider = new $factoryProvider();
             $decoratedServerRequestFactory = new DecoratedServerRequestFactory($provider->getServerRequestFactory());
 
             $request = $decoratedServerRequestFactory->createServerRequest('POST', 'https://google.com');
@@ -969,7 +969,7 @@ class ServerRequestTest extends TestCase
     {
         foreach ($this->factoryProviders as $factoryProvider) {
             /** @var Psr17FactoryProvider $provider */
-            $provider = new $factoryProvider;
+            $provider = new $factoryProvider();
             $decoratedServerRequestFactory = new DecoratedServerRequestFactory($provider->getServerRequestFactory());
 
             $request = $decoratedServerRequestFactory->createServerRequest('POST', 'https://google.com');
@@ -982,7 +982,7 @@ class ServerRequestTest extends TestCase
     {
         foreach ($this->factoryProviders as $factoryProvider) {
             /** @var Psr17FactoryProvider $provider */
-            $provider = new $factoryProvider;
+            $provider = new $factoryProvider();
             $decoratedServerRequestFactory = new DecoratedServerRequestFactory($provider->getServerRequestFactory());
 
             $request = $decoratedServerRequestFactory->createServerRequest('POST', 'https://google.com');
@@ -998,7 +998,7 @@ class ServerRequestTest extends TestCase
     {
         foreach ($this->factoryProviders as $factoryProvider) {
             /** @var Psr17FactoryProvider $provider */
-            $provider = new $factoryProvider;
+            $provider = new $factoryProvider();
             $decoratedServerRequestFactory = new DecoratedServerRequestFactory($provider->getServerRequestFactory());
 
             $request = $decoratedServerRequestFactory->createServerRequest('GET', 'https://google.com?foo=bar');
@@ -1010,7 +1010,7 @@ class ServerRequestTest extends TestCase
     {
         foreach ($this->factoryProviders as $factoryProvider) {
             /** @var Psr17FactoryProvider $provider */
-            $provider = new $factoryProvider;
+            $provider = new $factoryProvider();
             $decoratedServerRequestFactory = new DecoratedServerRequestFactory($provider->getServerRequestFactory());
 
             $request = $decoratedServerRequestFactory->createServerRequest('GET', 'https://google.com?foo=bar');
@@ -1022,7 +1022,7 @@ class ServerRequestTest extends TestCase
     {
         foreach ($this->factoryProviders as $factoryProvider) {
             /** @var Psr17FactoryProvider $provider */
-            $provider = new $factoryProvider;
+            $provider = new $factoryProvider();
             $decoratedServerRequestFactory = new DecoratedServerRequestFactory($provider->getServerRequestFactory());
 
             $request = $decoratedServerRequestFactory->createServerRequest('GET', 'https://google.com?foo=bar&bar=baz');
@@ -1034,7 +1034,7 @@ class ServerRequestTest extends TestCase
     {
         foreach ($this->factoryProviders as $factoryProvider) {
             /** @var Psr17FactoryProvider $provider */
-            $provider = new $factoryProvider;
+            $provider = new $factoryProvider();
             $decoratedServerRequestFactory = new DecoratedServerRequestFactory($provider->getServerRequestFactory());
 
             $streamFactory = $provider->getStreamFactory();
@@ -1053,7 +1053,7 @@ class ServerRequestTest extends TestCase
     {
         foreach ($this->factoryProviders as $factoryProvider) {
             /** @var Psr17FactoryProvider $provider */
-            $provider = new $factoryProvider;
+            $provider = new $factoryProvider();
             $decoratedServerRequestFactory = new DecoratedServerRequestFactory($provider->getServerRequestFactory());
 
             $streamFactory = $provider->getStreamFactory();
@@ -1072,7 +1072,7 @@ class ServerRequestTest extends TestCase
     {
         foreach ($this->factoryProviders as $factoryProvider) {
             /** @var Psr17FactoryProvider $provider */
-            $provider = new $factoryProvider;
+            $provider = new $factoryProvider();
             $decoratedServerRequestFactory = new DecoratedServerRequestFactory($provider->getServerRequestFactory());
 
             $streamFactory = $provider->getStreamFactory();
@@ -1091,7 +1091,7 @@ class ServerRequestTest extends TestCase
     {
         foreach ($this->factoryProviders as $factoryProvider) {
             /** @var Psr17FactoryProvider $provider */
-            $provider = new $factoryProvider;
+            $provider = new $factoryProvider();
             $decoratedServerRequestFactory = new DecoratedServerRequestFactory($provider->getServerRequestFactory());
 
             $request = $decoratedServerRequestFactory->createServerRequest('GET', 'https://google.com');
@@ -1105,7 +1105,7 @@ class ServerRequestTest extends TestCase
     {
         foreach ($this->factoryProviders as $factoryProvider) {
             /** @var Psr17FactoryProvider $provider */
-            $provider = new $factoryProvider;
+            $provider = new $factoryProvider();
             $decoratedServerRequestFactory = new DecoratedServerRequestFactory($provider->getServerRequestFactory());
 
             $request = $decoratedServerRequestFactory->createServerRequest('GET', 'https://google.com');
@@ -1121,7 +1121,7 @@ class ServerRequestTest extends TestCase
     {
         foreach ($this->factoryProviders as $factoryProvider) {
             /** @var Psr17FactoryProvider $provider */
-            $provider = new $factoryProvider;
+            $provider = new $factoryProvider();
             $decoratedServerRequestFactory = new DecoratedServerRequestFactory($provider->getServerRequestFactory());
 
             $request = $decoratedServerRequestFactory->createServerRequest('GET', 'https://google.com');
@@ -1136,7 +1136,7 @@ class ServerRequestTest extends TestCase
     {
         foreach ($this->factoryProviders as $factoryProvider) {
             /** @var Psr17FactoryProvider $provider */
-            $provider = new $factoryProvider;
+            $provider = new $factoryProvider();
             $decoratedServerRequestFactory = new DecoratedServerRequestFactory($provider->getServerRequestFactory());
 
             $request = $decoratedServerRequestFactory->createServerRequest('GET', 'https://google.com');
@@ -1150,7 +1150,7 @@ class ServerRequestTest extends TestCase
     {
         foreach ($this->factoryProviders as $factoryProvider) {
             /** @var Psr17FactoryProvider $provider */
-            $provider = new $factoryProvider;
+            $provider = new $factoryProvider();
             $decoratedServerRequestFactory = new DecoratedServerRequestFactory($provider->getServerRequestFactory());
 
             $request = $decoratedServerRequestFactory->createServerRequest('GET', 'https://google.com');
@@ -1166,7 +1166,7 @@ class ServerRequestTest extends TestCase
     {
         foreach ($this->factoryProviders as $factoryProvider) {
             /** @var Psr17FactoryProvider $provider */
-            $provider = new $factoryProvider;
+            $provider = new $factoryProvider();
             $decoratedServerRequestFactory = new DecoratedServerRequestFactory($provider->getServerRequestFactory());
 
             $request = $decoratedServerRequestFactory->createServerRequest('GET', 'https://google.com');

--- a/tests/UriTest.php
+++ b/tests/UriTest.php
@@ -19,7 +19,7 @@ class UriTest extends TestCase
     {
         foreach ($this->factoryProviders as $factoryProvider) {
             /** @var Psr17FactoryProvider $provider */
-            $provider = new $factoryProvider;
+            $provider = new $factoryProvider();
             $decoratedUriFactory = new DecoratedUriFactory($provider->getUriFactory());
 
             $uri = $decoratedUriFactory->createUri('https://google.com');
@@ -33,7 +33,7 @@ class UriTest extends TestCase
     {
         foreach ($this->factoryProviders as $factoryProvider) {
             /** @var Psr17FactoryProvider $provider */
-            $provider = new $factoryProvider;
+            $provider = new $factoryProvider();
             $decoratedUriFactory = new DecoratedUriFactory($provider->getUriFactory());
 
             $uri = $decoratedUriFactory->createUri('https://google.com');
@@ -45,7 +45,7 @@ class UriTest extends TestCase
     {
         foreach ($this->factoryProviders as $factoryProvider) {
             /** @var Psr17FactoryProvider $provider */
-            $provider = new $factoryProvider;
+            $provider = new $factoryProvider();
             $decoratedUriFactory = new DecoratedUriFactory($provider->getUriFactory());
 
             $uri = $decoratedUriFactory->createUri('https://google.com');
@@ -59,7 +59,7 @@ class UriTest extends TestCase
     {
         foreach ($this->factoryProviders as $factoryProvider) {
             /** @var Psr17FactoryProvider $provider */
-            $provider = new $factoryProvider;
+            $provider = new $factoryProvider();
             $decoratedUriFactory = new DecoratedUriFactory($provider->getUriFactory());
 
             $uri = $decoratedUriFactory->createUri('https://google.com');
@@ -73,7 +73,7 @@ class UriTest extends TestCase
     {
         foreach ($this->factoryProviders as $factoryProvider) {
             /** @var Psr17FactoryProvider $provider */
-            $provider = new $factoryProvider;
+            $provider = new $factoryProvider();
             $decoratedUriFactory = new DecoratedUriFactory($provider->getUriFactory());
 
             $uri = $decoratedUriFactory->createUri('https://google.com');
@@ -87,7 +87,7 @@ class UriTest extends TestCase
     {
         foreach ($this->factoryProviders as $factoryProvider) {
             /** @var Psr17FactoryProvider $provider */
-            $provider = new $factoryProvider;
+            $provider = new $factoryProvider();
             $decoratedUriFactory = new DecoratedUriFactory($provider->getUriFactory());
 
             $uri = $decoratedUriFactory->createUri('https://user@google.com');
@@ -101,7 +101,7 @@ class UriTest extends TestCase
     {
         foreach ($this->factoryProviders as $factoryProvider) {
             /** @var Psr17FactoryProvider $provider */
-            $provider = new $factoryProvider;
+            $provider = new $factoryProvider();
             $decoratedUriFactory = new DecoratedUriFactory($provider->getUriFactory());
 
             $uri = $decoratedUriFactory->createUri('https://user@google.com');
@@ -113,7 +113,7 @@ class UriTest extends TestCase
     {
         foreach ($this->factoryProviders as $factoryProvider) {
             /** @var Psr17FactoryProvider $provider */
-            $provider = new $factoryProvider;
+            $provider = new $factoryProvider();
             $decoratedUriFactory = new DecoratedUriFactory($provider->getUriFactory());
 
             $uri = $decoratedUriFactory->createUri('https://google.com:400');
@@ -125,7 +125,7 @@ class UriTest extends TestCase
     {
         foreach ($this->factoryProviders as $factoryProvider) {
             /** @var Psr17FactoryProvider $provider */
-            $provider = new $factoryProvider;
+            $provider = new $factoryProvider();
             $decoratedUriFactory = new DecoratedUriFactory($provider->getUriFactory());
 
             $uri = $decoratedUriFactory->createUri('https://google.com');
@@ -139,7 +139,7 @@ class UriTest extends TestCase
     {
         foreach ($this->factoryProviders as $factoryProvider) {
             /** @var Psr17FactoryProvider $provider */
-            $provider = new $factoryProvider;
+            $provider = new $factoryProvider();
             $decoratedUriFactory = new DecoratedUriFactory($provider->getUriFactory());
 
             $uri = $decoratedUriFactory->createUri('https://user%40pass%3Aword@google.com');
@@ -151,7 +151,7 @@ class UriTest extends TestCase
     {
         foreach ($this->factoryProviders as $factoryProvider) {
             /** @var Psr17FactoryProvider $provider */
-            $provider = new $factoryProvider;
+            $provider = new $factoryProvider();
             $decoratedUriFactory = new DecoratedUriFactory($provider->getUriFactory());
 
             $uri = $decoratedUriFactory->createUri('https://user@google.com');
@@ -163,7 +163,7 @@ class UriTest extends TestCase
     {
         foreach ($this->factoryProviders as $factoryProvider) {
             /** @var Psr17FactoryProvider $provider */
-            $provider = new $factoryProvider;
+            $provider = new $factoryProvider();
             $decoratedUriFactory = new DecoratedUriFactory($provider->getUriFactory());
 
             $uri = $decoratedUriFactory->createUri('https://google.com');
@@ -175,7 +175,7 @@ class UriTest extends TestCase
     {
         foreach ($this->factoryProviders as $factoryProvider) {
             /** @var Psr17FactoryProvider $provider */
-            $provider = new $factoryProvider;
+            $provider = new $factoryProvider();
             $decoratedUriFactory = new DecoratedUriFactory($provider->getUriFactory());
 
             $uri = $decoratedUriFactory->createUri('https://google.com');
@@ -187,7 +187,7 @@ class UriTest extends TestCase
     {
         foreach ($this->factoryProviders as $factoryProvider) {
             /** @var Psr17FactoryProvider $provider */
-            $provider = new $factoryProvider;
+            $provider = new $factoryProvider();
             $decoratedUriFactory = new DecoratedUriFactory($provider->getUriFactory());
 
             $uri = $decoratedUriFactory->createUri('https://google.com');
@@ -201,7 +201,7 @@ class UriTest extends TestCase
     {
         foreach ($this->factoryProviders as $factoryProvider) {
             /** @var Psr17FactoryProvider $provider */
-            $provider = new $factoryProvider;
+            $provider = new $factoryProvider();
             $decoratedUriFactory = new DecoratedUriFactory($provider->getUriFactory());
 
             $uri = $decoratedUriFactory->createUri('https://google.com');
@@ -215,7 +215,7 @@ class UriTest extends TestCase
     {
         foreach ($this->factoryProviders as $factoryProvider) {
             /** @var Psr17FactoryProvider $provider */
-            $provider = new $factoryProvider;
+            $provider = new $factoryProvider();
             $decoratedUriFactory = new DecoratedUriFactory($provider->getUriFactory());
 
             $uri = $decoratedUriFactory->createUri('https://google.com');
@@ -232,7 +232,7 @@ class UriTest extends TestCase
     {
         foreach ($this->factoryProviders as $factoryProvider) {
             /** @var Psr17FactoryProvider $provider */
-            $provider = new $factoryProvider;
+            $provider = new $factoryProvider();
             $decoratedUriFactory = new DecoratedUriFactory($provider->getUriFactory());
 
             $uri = $decoratedUriFactory->createUri('https://google.com');
@@ -247,7 +247,7 @@ class UriTest extends TestCase
     {
         foreach ($this->factoryProviders as $factoryProvider) {
             /** @var Psr17FactoryProvider $provider */
-            $provider = new $factoryProvider;
+            $provider = new $factoryProvider();
             $decoratedUriFactory = new DecoratedUriFactory($provider->getUriFactory());
 
             $uri = $decoratedUriFactory->createUri('https://google.com');
@@ -259,7 +259,7 @@ class UriTest extends TestCase
     {
         foreach ($this->factoryProviders as $factoryProvider) {
             /** @var Psr17FactoryProvider $provider */
-            $provider = new $factoryProvider;
+            $provider = new $factoryProvider();
             $decoratedUriFactory = new DecoratedUriFactory($provider->getUriFactory());
 
             $uri = $decoratedUriFactory->createUri('https://google.com/path');
@@ -271,7 +271,7 @@ class UriTest extends TestCase
     {
         foreach ($this->factoryProviders as $factoryProvider) {
             /** @var Psr17FactoryProvider $provider */
-            $provider = new $factoryProvider;
+            $provider = new $factoryProvider();
             $decoratedUriFactory = new DecoratedUriFactory($provider->getUriFactory());
 
             $uri = $decoratedUriFactory->createUri('https://google.com/path');
@@ -285,7 +285,7 @@ class UriTest extends TestCase
     {
         foreach ($this->factoryProviders as $factoryProvider) {
             /** @var Psr17FactoryProvider $provider */
-            $provider = new $factoryProvider;
+            $provider = new $factoryProvider();
             $decoratedUriFactory = new DecoratedUriFactory($provider->getUriFactory());
 
             $uri = $decoratedUriFactory->createUri('https://google.com/path');
@@ -299,7 +299,7 @@ class UriTest extends TestCase
     {
         foreach ($this->factoryProviders as $factoryProvider) {
             /** @var Psr17FactoryProvider $provider */
-            $provider = new $factoryProvider;
+            $provider = new $factoryProvider();
             $decoratedUriFactory = new DecoratedUriFactory($provider->getUriFactory());
 
             $uri = $decoratedUriFactory->createUri('https://google.com/path');
@@ -313,7 +313,7 @@ class UriTest extends TestCase
     {
         foreach ($this->factoryProviders as $factoryProvider) {
             /** @var Psr17FactoryProvider $provider */
-            $provider = new $factoryProvider;
+            $provider = new $factoryProvider();
             $decoratedUriFactory = new DecoratedUriFactory($provider->getUriFactory());
 
             $uri = $decoratedUriFactory->createUri('https://google.com/path?foo=bar');
@@ -325,7 +325,7 @@ class UriTest extends TestCase
     {
         foreach ($this->factoryProviders as $factoryProvider) {
             /** @var Psr17FactoryProvider $provider */
-            $provider = new $factoryProvider;
+            $provider = new $factoryProvider();
             $decoratedUriFactory = new DecoratedUriFactory($provider->getUriFactory());
 
             $uri = $decoratedUriFactory->createUri('https://google.com/path?foo=bar');
@@ -339,7 +339,7 @@ class UriTest extends TestCase
     {
         foreach ($this->factoryProviders as $factoryProvider) {
             /** @var Psr17FactoryProvider $provider */
-            $provider = new $factoryProvider;
+            $provider = new $factoryProvider();
             $decoratedUriFactory = new DecoratedUriFactory($provider->getUriFactory());
 
             $uri = $decoratedUriFactory->createUri('https://google.com/path?foo=bar');
@@ -353,7 +353,7 @@ class UriTest extends TestCase
     {
         foreach ($this->factoryProviders as $factoryProvider) {
             /** @var Psr17FactoryProvider $provider */
-            $provider = new $factoryProvider;
+            $provider = new $factoryProvider();
             $decoratedUriFactory = new DecoratedUriFactory($provider->getUriFactory());
 
             $uri = $decoratedUriFactory->createUri('https://google.com/#fragment');
@@ -365,7 +365,7 @@ class UriTest extends TestCase
     {
         foreach ($this->factoryProviders as $factoryProvider) {
             /** @var Psr17FactoryProvider $provider */
-            $provider = new $factoryProvider;
+            $provider = new $factoryProvider();
             $decoratedUriFactory = new DecoratedUriFactory($provider->getUriFactory());
 
             $uri = $decoratedUriFactory->createUri('https://google.com/#fragment');
@@ -379,7 +379,7 @@ class UriTest extends TestCase
     {
         foreach ($this->factoryProviders as $factoryProvider) {
             /** @var Psr17FactoryProvider $provider */
-            $provider = new $factoryProvider;
+            $provider = new $factoryProvider();
             $decoratedUriFactory = new DecoratedUriFactory($provider->getUriFactory());
 
             $uri = $decoratedUriFactory->createUri('https://google.com/#fragment');
@@ -393,7 +393,7 @@ class UriTest extends TestCase
     {
         foreach ($this->factoryProviders as $factoryProvider) {
             /** @var Psr17FactoryProvider $provider */
-            $provider = new $factoryProvider;
+            $provider = new $factoryProvider();
             $decoratedUriFactory = new DecoratedUriFactory($provider->getUriFactory());
 
             $uri = $decoratedUriFactory->createUri('https://user@google.com/path/otherpath?foo=bar#fragment');
@@ -411,7 +411,7 @@ class UriTest extends TestCase
     {
         foreach ($this->factoryProviders as $factoryProvider) {
             /** @var Psr17FactoryProvider $provider */
-            $provider = new $factoryProvider;
+            $provider = new $factoryProvider();
             $decoratedUriFactory = new DecoratedUriFactory($provider->getUriFactory());
 
             $uri = $decoratedUriFactory->createUri('https://google.com/path/otherpath?foo=bar#fragment');
@@ -423,7 +423,7 @@ class UriTest extends TestCase
     {
         foreach ($this->factoryProviders as $factoryProvider) {
             /** @var Psr17FactoryProvider $provider */
-            $provider = new $factoryProvider;
+            $provider = new $factoryProvider();
             $decoratedUriFactory = new DecoratedUriFactory($provider->getUriFactory());
 
             $uri = $decoratedUriFactory->createUri('https://google.com/index.php');
@@ -435,7 +435,7 @@ class UriTest extends TestCase
     {
         foreach ($this->factoryProviders as $factoryProvider) {
             /** @var Psr17FactoryProvider $provider */
-            $provider = new $factoryProvider;
+            $provider = new $factoryProvider();
             $decoratedUriFactory = new DecoratedUriFactory($provider->getUriFactory());
 
             $uri = $decoratedUriFactory->createUri('https://user:password@google.com/path/otherpath?foo=bar#fragment');


### PR DESCRIPTION
Resuming to adopt the proposed direction in #88

**New Response Methods:**
- Response::withFile($file, $contentType)
- Response::withFileDownload($file, $name, $contentType)

**Behavior**
The `$file` parameter can be a `string` which points to a file, an existing `resource` handle or a `StreamInterface` as proposed by @roxblnfk

The `$name` parameter overrides the default `attachment` value for the `Content-Disposition` header. The given `$name` is filtered through `urlencode()` to ensure it is a valid header value.

The `$contentType` parameter accepts a `string` to override the `Content-Type` header to a user defined value. Defaults to `true` which attempts to detect the mime type via `mime_content_type()` and falls back to `application/octet-stream` otherwise. If set to `false` the `Content-Type` header is not appended at all.

Closes #82