### PR TITLE
Add test case for ServerRequest::getMediaType()

### DIFF
--- a/tests/Assets/PhpFunctionOverrides.php
+++ b/tests/Assets/PhpFunctionOverrides.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * Slim Framework (https://slimframework.com)
+ *
+ * @license https://github.com/slimphp/Slim-Http/blob/master/LICENSE.md (MIT License)
+ */
+
+declare(strict_types=1);
+
+namespace Slim\Http;
+
+/**
+ * Return global set value if set or value from php built-in function.
+ *
+ * @param string $pattern
+ * @param string $subject
+ * @param int    $limit
+ * @param int    $flags
+ *
+ * @return array[]|false|mixed|string[]
+ */
+function preg_split(string $pattern, string $subject, int $limit = -1, int $flags = 0)
+{
+    if (isset($GLOBALS['preg_split_return'])) {
+        return $GLOBALS['preg_split_return'];
+    }
+
+    return \preg_split($pattern, $subject, $limit, $flags);
+}

--- a/tests/ServerRequestTest.php
+++ b/tests/ServerRequestTest.php
@@ -315,6 +315,22 @@ class ServerRequestTest extends TestCase
         }
     }
 
+    public function testGetMediaTypeInvalid()
+    {
+        foreach ($this->factoryProviders as $factoryProvider) {
+            /** @var Psr17FactoryProvider $provider */
+            $provider = new $factoryProvider();
+            $decoratedServerRequestFactory = new DecoratedServerRequestFactory($provider->getServerRequestFactory());
+
+            $request = $decoratedServerRequestFactory->createServerRequest('GET', 'https://google.com');
+            $request = $request->withHeader('Content-Type', 'application/pdf');
+
+            $GLOBALS['preg_split_return'] = false;
+            $this->assertNull($request->getMediaType());
+            unset($GLOBALS['preg_split_return']);
+        }
+    }
+
     public function testGetMediaTypeParams()
     {
         foreach ($this->factoryProviders as $factoryProvider) {

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -8,3 +8,5 @@
 declare(strict_types=1);
 
 require __DIR__ . '/../vendor/autoload.php';
+
+require __DIR__ . '/Assets/PhpFunctionOverrides.php';


### PR DESCRIPTION
This PR adds a test case to test it the method `\Slim\Http\ServerRequest::getMediaType()` would return `null` in case the php built-in function `preg_split()` fails.

In order to do that, I had to override the php built-in function.