### PR TITLE
Remove charset on json content-type

### DIFF
--- a/src/Response.php
+++ b/src/Response.php
@@ -194,7 +194,7 @@ class Response implements ResponseInterface
         }
 
         $response = $this->response
-            ->withHeader('Content-Type', 'application/json;charset=utf-8')
+            ->withHeader('Content-Type', 'application/json')
             ->withBody($this->streamFactory->createStream($json));
 
         if ($status !== null) {

--- a/tests/ResponseTest.php
+++ b/tests/ResponseTest.php
@@ -607,7 +607,7 @@ class ResponseTest extends TestCase
 
             $this->assertNotEquals($response->getStatusCode(), $originalResponse->getStatusCode());
             $this->assertEquals(201, $response->getStatusCode());
-            $this->assertEquals('application/json;charset=utf-8', $response->getHeaderLine('Content-Type'));
+            $this->assertEquals('application/json', $response->getHeaderLine('Content-Type'));
 
             $body = $response->getBody();
             $body->rewind();


### PR DESCRIPTION
Instead of application/json; charset=utf-8, we should simply return application/json without the ; charset=utf-8 suffix.

More details: https://github.com/slimphp/Slim/issues/2629