### PR TITLE
PHPUnit 8, PHP 7.2 and Laminas

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 composer.lock
 vendor/
 /.tmp
+*.cache

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,16 +4,16 @@ dist: trusty
 
 matrix:
   include:
-  - php: 7.1
-    env: ANALYSIS='true'
   - php: 7.2
   - php: 7.3
+  - php: 7.4
+    env: ANALYSIS='true'
   - php: nightly
   allow_failures:
   - php: nightly
 
 before_script:
-- composer require php-coveralls/php-coveralls:^2.1.0
+- if [[ "$ANALYSIS" == 'true' ]]; then composer require php-coveralls/php-coveralls:^2.2.0 ; fi
 - composer install -n
 
 script:

--- a/composer.json
+++ b/composer.json
@@ -32,14 +32,14 @@
     "ext-json": "*",
     "ext-libxml": "*",
     "ext-SimpleXML": "*",
-    "php": "^7.1",
+    "php": "^7.2",
     "psr/http-factory": "^1.0",
     "psr/http-message": "^1.0"
   },
   "require-dev": {
     "nyholm/psr7": "^1.0",
     "phpstan/phpstan": "^0.10.3",
-    "phpunit/phpunit": "^7.0",
+    "phpunit/phpunit": "^8.5",
     "php-http/psr7-integration-tests": "dev-master",
     "squizlabs/php_codesniffer": "^3.3.2",
     "zendframework/zend-diactoros": "^2.0"

--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,7 @@
     "phpunit/phpunit": "^8.5",
     "php-http/psr7-integration-tests": "dev-master",
     "squizlabs/php_codesniffer": "^3.3.2",
-    "zendframework/zend-diactoros": "^2.0"
+    "laminas/laminas-diactoros": "^2.0"
   },
   "provide": {
     "psr/http-factory": "^1.0"

--- a/tests/Providers/LaminasDiactorosPsr17FactoryProvider.php
+++ b/tests/Providers/LaminasDiactorosPsr17FactoryProvider.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * Slim Framework (https://slimframework.com)
+ *
+ * @license https://github.com/slimphp/Slim-Http/blob/master/LICENSE.md (MIT License)
+ */
+
+declare(strict_types=1);
+
+namespace Slim\Tests\Http\Providers;
+
+use Laminas\Diactoros\ResponseFactory;
+use Laminas\Diactoros\ServerRequestFactory;
+use Laminas\Diactoros\StreamFactory;
+use Laminas\Diactoros\UploadedFileFactory;
+use Laminas\Diactoros\UriFactory;
+
+class LaminasDiactorosPsr17FactoryProvider extends Psr17FactoryProvider
+{
+    public function __construct()
+    {
+        $this->responseFactory = new ResponseFactory();
+        $this->serverRequestFactory = new ServerRequestFactory();
+        $this->streamFactory = new StreamFactory();
+        $this->uploadedFileFactory = new UploadedFileFactory();
+        $this->uriFactory = new UriFactory();
+    }
+}

--- a/tests/Psr7Integration/Laminas/ResponseTest.php
+++ b/tests/Psr7Integration/Laminas/ResponseTest.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * Slim Framework (https://slimframework.com)
+ *
+ * @license https://github.com/slimphp/Slim-Http/blob/master/LICENSE.md (MIT License)
+ */
+
+declare(strict_types=1);
+
+namespace Slim\Tests\Http\Psr7Integration\Laminas;
+
+use Http\Psr7Test\ResponseIntegrationTest;
+use Laminas\Diactoros\StreamFactory;
+use Slim\Http\Factory\DecoratedResponseFactory;
+use Slim\Tests\Http\Providers\LaminasDiactorosPsr17FactoryProvider;
+
+class ResponseTest extends ResponseIntegrationTest
+{
+    public static function setUpBeforeClass(): void
+    {
+        if (!defined('STREAM_FACTORY')) {
+            define('STREAM_FACTORY', StreamFactory::class);
+        }
+    }
+
+    public function createSubject()
+    {
+        $provider = new LaminasDiactorosPsr17FactoryProvider();
+        $decoratedResponseFactory = new DecoratedResponseFactory(
+            $provider->getResponseFactory(),
+            $provider->getStreamFactory()
+        );
+
+        return $decoratedResponseFactory->createResponse();
+    }
+}

--- a/tests/Psr7Integration/Laminas/ServerRequestTest.php
+++ b/tests/Psr7Integration/Laminas/ServerRequestTest.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * Slim Framework (https://slimframework.com)
+ *
+ * @license https://github.com/slimphp/Slim-Http/blob/master/LICENSE.md (MIT License)
+ */
+
+declare(strict_types=1);
+
+namespace Slim\Tests\Http\Psr7Integration\Laminas;
+
+use Http\Psr7Test\ServerRequestIntegrationTest;
+use Laminas\Diactoros\StreamFactory;
+use Slim\Http\Factory\DecoratedServerRequestFactory;
+use Slim\Tests\Http\Providers\LaminasDiactorosPsr17FactoryProvider;
+
+class ServerRequestTest extends ServerRequestIntegrationTest
+{
+    public static function setUpBeforeClass(): void
+    {
+        if (!defined('STREAM_FACTORY')) {
+            define('STREAM_FACTORY', StreamFactory::class);
+        }
+    }
+
+    public function createSubject()
+    {
+        $provider = new LaminasDiactorosPsr17FactoryProvider();
+        $decoratedServerRequestFactory = new DecoratedServerRequestFactory($provider->getServerRequestFactory());
+
+        return $decoratedServerRequestFactory->createServerRequest('GET', 'http://foo.com', $_SERVER);
+    }
+}

--- a/tests/Psr7Integration/Laminas/UriTest.php
+++ b/tests/Psr7Integration/Laminas/UriTest.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * Slim Framework (https://slimframework.com)
+ *
+ * @license https://github.com/slimphp/Slim-Http/blob/master/LICENSE.md (MIT License)
+ */
+
+declare(strict_types=1);
+
+namespace Slim\Tests\Http\Psr7Integration\Laminas;
+
+use Http\Psr7Test\UriIntegrationTest;
+use Laminas\Diactoros\StreamFactory;
+use Slim\Http\Factory\DecoratedUriFactory;
+use Slim\Tests\Http\Providers\LaminasDiactorosPsr17FactoryProvider;
+
+class UriTest extends UriIntegrationTest
+{
+    public static function setUpBeforeClass(): void
+    {
+        if (!defined('STREAM_FACTORY')) {
+            define('STREAM_FACTORY', StreamFactory::class);
+        }
+    }
+
+    public function createUri($uri)
+    {
+        $provider = new LaminasDiactorosPsr17FactoryProvider();
+        $decoratedUriFactory = new DecoratedUriFactory($provider->getUriFactory());
+
+        return $decoratedUriFactory->createUri($uri);
+    }
+}

--- a/tests/Psr7Integration/Nyholm/ResponseTest.php
+++ b/tests/Psr7Integration/Nyholm/ResponseTest.php
@@ -16,7 +16,7 @@ use Slim\Tests\Http\Providers\NyholmPsr17FactoryProvider;
 
 class ResponseTest extends ResponseIntegrationTest
 {
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         if (!defined('STREAM_FACTORY')) {
             define('STREAM_FACTORY', Psr17Factory::class);

--- a/tests/Psr7Integration/Nyholm/ServerRequestTest.php
+++ b/tests/Psr7Integration/Nyholm/ServerRequestTest.php
@@ -16,7 +16,7 @@ use Slim\Tests\Http\Providers\NyholmPsr17FactoryProvider;
 
 class ServerRequestTest extends ServerRequestIntegrationTest
 {
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         if (!defined('STREAM_FACTORY')) {
             define('STREAM_FACTORY', Psr17Factory::class);

--- a/tests/Psr7Integration/Nyholm/UriTest.php
+++ b/tests/Psr7Integration/Nyholm/UriTest.php
@@ -16,7 +16,7 @@ use Slim\Tests\Http\Providers\NyholmPsr17FactoryProvider;
 
 class UriTest extends UriIntegrationTest
 {
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         if (!defined('STREAM_FACTORY')) {
             define('STREAM_FACTORY', Psr17Factory::class);

--- a/tests/Psr7Integration/Zend/ResponseTest.php
+++ b/tests/Psr7Integration/Zend/ResponseTest.php
@@ -16,7 +16,7 @@ use Zend\Diactoros\StreamFactory;
 
 class ResponseTest extends ResponseIntegrationTest
 {
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         if (!defined('STREAM_FACTORY')) {
             define('STREAM_FACTORY', StreamFactory::class);

--- a/tests/Psr7Integration/Zend/ServerRequestTest.php
+++ b/tests/Psr7Integration/Zend/ServerRequestTest.php
@@ -16,7 +16,7 @@ use Zend\Diactoros\StreamFactory;
 
 class ServerRequestTest extends ServerRequestIntegrationTest
 {
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         if (!defined('STREAM_FACTORY')) {
             define('STREAM_FACTORY', StreamFactory::class);

--- a/tests/Psr7Integration/Zend/UriTest.php
+++ b/tests/Psr7Integration/Zend/UriTest.php
@@ -16,7 +16,7 @@ use Zend\Diactoros\StreamFactory;
 
 class UriTest extends UriIntegrationTest
 {
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         if (!defined('STREAM_FACTORY')) {
             define('STREAM_FACTORY', StreamFactory::class);

--- a/tests/ResponseTest.php
+++ b/tests/ResponseTest.php
@@ -309,11 +309,10 @@ class ResponseTest extends TestCase
         }
     }
 
-    /**
-     * @expectedException InvalidArgumentException
-     */
     public function testWithFileThrowsInvalidArgumentException()
     {
+        $this->expectException(InvalidArgumentException::class);
+
         foreach ($this->factoryProviders as $factoryProvider) {
             /** @var Psr17FactoryProvider $provider */
             $provider = new $factoryProvider();
@@ -636,11 +635,10 @@ class ResponseTest extends TestCase
         }
     }
 
-    /**
-     * @expectedException RuntimeException
-     */
     public function testWithInvalidJsonThrowsException()
     {
+        $this->expectException(RuntimeException::class);
+
         $data = ['foo' => 'bar'.chr(233)];
         $this->assertEquals('bar'.chr(233), $data['foo']);
 

--- a/tests/ServerRequestTest.php
+++ b/tests/ServerRequestTest.php
@@ -93,11 +93,10 @@ class ServerRequestTest extends TestCase
         }
     }
 
-    /**
-     * @expectedException InvalidArgumentException
-     */
     public function testWithMethodInvalid()
     {
+        $this->expectException(InvalidArgumentException::class);
+
         foreach ($this->factoryProviders as $factoryProvider) {
             /** @var Psr17FactoryProvider $provider */
             $provider = new $factoryProvider();
@@ -957,11 +956,10 @@ class ServerRequestTest extends TestCase
         }
     }
 
-    /**
-     * @expectedException RuntimeException
-     */
     public function testGetParsedBodyThrowsRuntimeExceptionWhenInvalidTypeReturned()
     {
+        $this->expectException(RuntimeException::class);
+
         foreach ($this->factoryProviders as $factoryProvider) {
             /** @var Psr17FactoryProvider $provider */
             $provider = new $factoryProvider();

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 namespace Slim\Tests\Http;
 
 use PHPUnit\Framework\TestCase as PHPUnitTestCase;
+use Slim\Tests\Http\Providers\LaminasDiactorosPsr17FactoryProvider;
 use Slim\Tests\Http\Providers\NyholmPsr17FactoryProvider;
 use Slim\Tests\Http\Providers\ZendDiactorosPsr17FactoryProvider;
 
@@ -21,5 +22,6 @@ abstract class TestCase extends PHPUnitTestCase
     protected $factoryProviders = [
         NyholmPsr17FactoryProvider::class,
         ZendDiactorosPsr17FactoryProvider::class,
+        LaminasDiactorosPsr17FactoryProvider::class
     ];
 }

--- a/tests/UriTest.php
+++ b/tests/UriTest.php
@@ -225,11 +225,10 @@ class UriTest extends TestCase
         }
     }
 
-    /**
-     * @expectedException InvalidArgumentException
-     */
     public function testWithPortInvalidInt()
     {
+        $this->expectException(InvalidArgumentException::class);
+
         foreach ($this->factoryProviders as $factoryProvider) {
             /** @var Psr17FactoryProvider $provider */
             $provider = new $factoryProvider();
@@ -240,11 +239,10 @@ class UriTest extends TestCase
         }
     }
 
-    /**
-     * @expectedException InvalidArgumentException
-     */
     public function testWithPortInvalidString()
     {
+        $this->expectException(InvalidArgumentException::class);
+
         foreach ($this->factoryProviders as $factoryProvider) {
             /** @var Psr17FactoryProvider $provider */
             $provider = new $factoryProvider();


### PR DESCRIPTION
This PR would set PHPUnit to version 8 and the minimal PHP version to 7.2. It would also add Laminas Diactoros as PSR7. Zend is left in there.