### PR TITLE
Update php-autoload-override version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,7 @@
     "psr/http-message": "^1.0"
   },
   "require-dev": {
-    "adriansuter/php-autoload-override": "v0.1-beta",
+    "adriansuter/php-autoload-override": "^1.0",
     "laminas/laminas-diactoros": "^2.0",
     "nyholm/psr7": "^1.0",
     "php-http/psr7-integration-tests": "dev-master",


### PR DESCRIPTION
This PR updates the version for the php-autoload-override library.