### PR TITLE
Update phpstan to ^0.12.23

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -41,7 +41,7 @@
     "laminas/laminas-diactoros": "^2.3",
     "nyholm/psr7": "^1.2",
     "php-http/psr7-integration-tests": "dev-master",
-    "phpstan/phpstan": "^0.10.3",
+    "phpstan/phpstan": "^0.12.23",
     "phpunit/phpunit": "^8.5",
     "squizlabs/php_codesniffer": "^3.5"
   },

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,2 +1,3 @@
 parameters:
+  checkMissingIterableValueType: false
   level: max

--- a/src/Factory/DecoratedServerRequestFactory.php
+++ b/src/Factory/DecoratedServerRequestFactory.php
@@ -33,7 +33,7 @@ class DecoratedServerRequestFactory implements ServerRequestFactoryInterface
     /**
      * @param string $method
      * @param UriInterface|string $uri
-     * @param array $serverParams
+     * @param array{key: string, value: mixed}|array<mixed> $serverParams
      * @return ServerRequest
      */
     public function createServerRequest(string $method, $uri, array $serverParams = []): ServerRequestInterface

--- a/src/Response.php
+++ b/src/Response.php
@@ -57,7 +57,7 @@ class Response implements ResponseInterface
      * @param ResponseInterface $response
      * @param StreamFactoryInterface $streamFactory
      */
-    public final function __construct(ResponseInterface $response, StreamFactoryInterface $streamFactory)
+    final public function __construct(ResponseInterface $response, StreamFactoryInterface $streamFactory)
     {
         $this->response = $response;
         $this->streamFactory = $streamFactory;

--- a/src/Response.php
+++ b/src/Response.php
@@ -57,7 +57,7 @@ class Response implements ResponseInterface
      * @param ResponseInterface $response
      * @param StreamFactoryInterface $streamFactory
      */
-    public function __construct(ResponseInterface $response, StreamFactoryInterface $streamFactory)
+    public final function __construct(ResponseInterface $response, StreamFactoryInterface $streamFactory)
     {
         $this->response = $response;
         $this->streamFactory = $streamFactory;
@@ -67,9 +67,11 @@ class Response implements ResponseInterface
      * Disable magic setter to ensure immutability
      * @param mixed $name
      * @param mixed $value
+     * @return void
      */
     public function __set($name, $value)
     {
+        return;
     }
 
     /**

--- a/src/ServerRequest.php
+++ b/src/ServerRequest.php
@@ -47,7 +47,7 @@ class ServerRequest implements ServerRequestInterface
     /**
      * @param ServerRequestInterface $serverRequest
      */
-    public function __construct(ServerRequestInterface $serverRequest)
+    public final function __construct(ServerRequestInterface $serverRequest)
     {
         $this->serverRequest = $serverRequest;
 
@@ -103,9 +103,11 @@ class ServerRequest implements ServerRequestInterface
      * Disable magic setter to ensure immutability
      * @param mixed $name
      * @param mixed $value
+     * @return void
      */
     public function __set($name, $value)
     {
+        return;
     }
 
     /**

--- a/src/ServerRequest.php
+++ b/src/ServerRequest.php
@@ -47,7 +47,7 @@ class ServerRequest implements ServerRequestInterface
     /**
      * @param ServerRequestInterface $serverRequest
      */
-    public final function __construct(ServerRequestInterface $serverRequest)
+    final public function __construct(ServerRequestInterface $serverRequest)
     {
         $this->serverRequest = $serverRequest;
 

--- a/src/Uri.php
+++ b/src/Uri.php
@@ -22,7 +22,7 @@ class Uri implements UriInterface
     /**
      * @param UriInterface $uri
      */
-    public function __construct(UriInterface $uri)
+    public final function __construct(UriInterface $uri)
     {
         $this->uri = $uri;
     }
@@ -31,9 +31,11 @@ class Uri implements UriInterface
      * Disable magic setter to ensure immutability
      * @param mixed $name
      * @param mixed $value
+     * @return void
      */
     public function __set($name, $value)
     {
+        return;
     }
 
     /**

--- a/src/Uri.php
+++ b/src/Uri.php
@@ -22,7 +22,7 @@ class Uri implements UriInterface
     /**
      * @param UriInterface $uri
      */
-    public final function __construct(UriInterface $uri)
+    final public function __construct(UriInterface $uri)
     {
         $this->uri = $uri;
     }


### PR DESCRIPTION
Closes #115

Note, the constructors of these objects are now final:
- ServerRequest
- Response
- URI

This is actually a BC change if they were extended. I have a feeling this is highly unlikely though.