### PR TITLE
Correct ServerRequest::getParam method PHPDoc

### DIFF
--- a/src/ServerRequest.php
+++ b/src/ServerRequest.php
@@ -552,7 +552,7 @@ class ServerRequest implements ServerRequestInterface
      * Note: This method is not part of the PSR-7 standard.
      *
      * @param  string $key The parameter key.
-     * @param  string $default The default value.
+     * @param  mixed  $default The default value.
      *
      * @return mixed The parameter value.
      */


### PR DESCRIPTION
The PHPDoc type of ServerRequest class getParam method's $default argument
is changed from "string" to "mixed", as dependent on request parameter its
default value can be expected to have another type(e.g. boolean). And if
there is a PHPStan or other analyser running in project an error is reported on
cases, where $default argument type is not string.  So as there is no obstacle for
doing this change, it is correct to change PHPDoc type of the argument.