### PR TITLE
Fix the composer provide rule

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -45,9 +45,6 @@
     "phpunit/phpunit": "^8.5",
     "squizlabs/php_codesniffer": "^3.5"
   },
-  "provide": {
-    "psr/http-factory-implementation": "1.0"
-  },
   "autoload": {
     "psr-4": {
       "Slim\\Http\\": "src/"

--- a/composer.json
+++ b/composer.json
@@ -46,7 +46,7 @@
     "squizlabs/php_codesniffer": "^3.5"
   },
   "provide": {
-    "psr/http-factory": "^1.0"
+    "psr/http-factory-implementation": "1.0"
   },
   "autoload": {
     "psr-4": {


### PR DESCRIPTION
This package does not provide the code of the psr/http-factory package (which defines interfaces). It provides psr/http-factory-implementation which is the virtual package to represent implementations of the interface.
Providing the wrong package while also requiring it creates issues with Composer 2, because the solver will consider that install psr/http-factory is not necessary as it is already provided.

Refs https://github.com/composer/composer/issues/9316
Closes #137