### PR TITLE
PHP 8 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
     }
   ],
   "require": {
-    "php": "^7.2",
+    "php": "^7.2 || ^8.0",
     "ext-SimpleXML": "*",
     "ext-fileinfo": "*",
     "ext-json": "*",
@@ -42,7 +42,7 @@
     "nyholm/psr7": "^1.3",
     "php-http/psr7-integration-tests": "dev-master",
     "phpstan/phpstan": "^0.12.52",
-    "phpunit/phpunit": "^8.5",
+    "phpunit/phpunit": "^8.5 || ^9.3",
     "squizlabs/php_codesniffer": "^3.5"
   },
   "autoload": {


### PR DESCRIPTION
This PR allows Slim to be installed in PHP 8 and passes all the tests and checks.

See also https://github.com/slimphp/Slim/pull/3015 and https://github.com/slimphp/Slim-Psr7/pull/169 for corresponding changes.

The same questions apply here:

* I implemented `disableXmlEntityLoader` as a `private static method`. Is this okay? I thought about making it `protected` or extracting it to a class, but I'm unsure about creating new "contracts".
* Coverage – conditional call to `libxml_disable_entity_loader`. Is it okay to just `@codeCoverageIgnore` some part that will only run in PHP 7 or PHP 8? How should situations like this be handled?

**Dependencies:** all dependencies have PHP 8-compatible releases now!

* [x] https://github.com/laminas/laminas-diactoros/pull/46
