### PR TITLE
add charset=utf-8 to withJson response

### DIFF
--- a/src/Response.php
+++ b/src/Response.php
@@ -214,7 +214,7 @@ class Response implements ResponseInterface
         }
 
         $response = $this->response
-            ->withHeader('Content-Type', 'application/json')
+            ->withHeader('Content-Type', 'application/json; charset=utf-8')
             ->withBody($this->streamFactory->createStream($json));
 
         if ($status !== null) {

--- a/tests/ResponseTest.php
+++ b/tests/ResponseTest.php
@@ -616,7 +616,7 @@ class ResponseTest extends TestCase
 
             $this->assertNotEquals($response->getStatusCode(), $originalResponse->getStatusCode());
             $this->assertEquals(201, $response->getStatusCode());
-            $this->assertEquals('application/json', $response->getHeaderLine('Content-Type'));
+            $this->assertEquals('application/json; charset=utf-8', $response->getHeaderLine('Content-Type'));
 
             $body = $response->getBody();
             $body->rewind();


### PR DESCRIPTION
Requesting the addition of a charset with the withJson response. This PR sets it to uff-8; maybe a parameter with a default value would be preferable.