### PR TITLE
Drop support for PHP 7.3

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: [7.3, 7.4, 8.0, 8.1]
+        php: [7.4, 8.0, 8.1]
         experimental: [false]
         include:
           - php: 8.1

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Set up PHP ${{ matrix.php }}
         uses: shivammathur/setup-php@v2
@@ -27,7 +27,7 @@ jobs:
           coverage: xdebug
 
       - name: Install dependencies with Composer
-        uses: ramsey/composer-install@v1
+        uses: ramsey/composer-install@v2
 
       - name: Coding standards
         if: matrix.analysis

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ $ composer require slim/http
 ```
 
 This will install the `slim/http` component and all required dependencies.
-PHP 7.3, or newer, is required.
+PHP 7.4, or newer, is required.
 
 ## Tests
 

--- a/composer.json
+++ b/composer.json
@@ -1,71 +1,75 @@
 {
-  "name": "slim/http",
-  "type": "library",
-  "description": "Slim PSR-7 Object Decorators",
-  "keywords": ["psr7", "psr-7", "http"],
-  "homepage": "http://slimframework.com",
-  "license": "MIT",
-  "authors": [
-    {
-      "name": "Josh Lockhart",
-      "email": "hello@joshlockhart.com",
-      "homepage": "http://joshlockhart.com"
-    },
-    {
-      "name": "Andrew Smith",
-      "email": "a.smith@silentworks.co.uk",
-      "homepage": "http://silentworks.co.uk"
-    },
-    {
-      "name": "Rob Allen",
-      "email": "rob@akrabat.com",
-      "homepage": "http://akrabat.com"
-    },
-    {
-      "name": "Pierre Berube",
-      "email": "pierre@lgse.com",
-      "homepage": "http://www.lgse.com"
-    }
-  ],
-  "require": {
-    "php": "^7.4 || ^8.0",
-    "ext-SimpleXML": "*",
-    "ext-fileinfo": "*",
-    "ext-json": "*",
-    "ext-libxml": "*",
-    "psr/http-factory": "^1.0",
-    "psr/http-message": "^1.0"
-  },
-  "require-dev": {
-    "adriansuter/php-autoload-override": "^1.2",
-    "laminas/laminas-diactoros": "^2.8",
-    "nyholm/psr7": "^1.5",
-    "php-http/psr7-integration-tests": "dev-master",
-    "phpstan/phpstan": "^1.4",
-    "phpunit/phpunit": "^9.5",
-    "squizlabs/php_codesniffer": "^3.6"
-  },
-  "autoload": {
-    "psr-4": {
-      "Slim\\Http\\": "src/"
-    }
-  },
-  "autoload-dev": {
-    "psr-4": {
-      "Slim\\Tests\\Http\\": "tests/"
-    }
-  },
-  "scripts": {
-    "test": [
-      "@phpunit",
-      "@phpcs",
-      "@phpstan"
+    "name": "slim/http",
+    "type": "library",
+    "description": "Slim PSR-7 Object Decorators",
+    "keywords": [
+        "psr7",
+        "psr-7",
+        "http"
     ],
-    "phpunit": "phpunit",
-    "phpcs": "phpcs",
-    "phpstan": "phpstan --memory-limit=-1"
-  },
-  "config": {
-    "sort-packages": true
-  }
+    "homepage": "http://slimframework.com",
+    "license": "MIT",
+    "authors": [
+        {
+            "name": "Josh Lockhart",
+            "email": "hello@joshlockhart.com",
+            "homepage": "http://joshlockhart.com"
+        },
+        {
+            "name": "Andrew Smith",
+            "email": "a.smith@silentworks.co.uk",
+            "homepage": "http://silentworks.co.uk"
+        },
+        {
+            "name": "Rob Allen",
+            "email": "rob@akrabat.com",
+            "homepage": "http://akrabat.com"
+        },
+        {
+            "name": "Pierre Berube",
+            "email": "pierre@lgse.com",
+            "homepage": "http://www.lgse.com"
+        }
+    ],
+    "require": {
+        "php": "^7.4 || ^8.0",
+        "ext-SimpleXML": "*",
+        "ext-fileinfo": "*",
+        "ext-json": "*",
+        "ext-libxml": "*",
+        "psr/http-factory": "^1.0",
+        "psr/http-message": "^1.0"
+    },
+    "require-dev": {
+        "adriansuter/php-autoload-override": "^1.2",
+        "laminas/laminas-diactoros": "^2.8",
+        "nyholm/psr7": "^1.5",
+        "php-http/psr7-integration-tests": "dev-master",
+        "phpstan/phpstan": "^1.4",
+        "phpunit/phpunit": "^9.5",
+        "squizlabs/php_codesniffer": "^3.6"
+    },
+    "autoload": {
+        "psr-4": {
+            "Slim\\Http\\": "src/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Slim\\Tests\\Http\\": "tests/"
+        }
+    },
+    "scripts": {
+        "test": [
+            "@phpunit",
+            "@phpcs",
+            "@phpstan"
+        ],
+        "phpunit": "phpunit",
+        "phpcs": "phpcs",
+        "phpstan": "phpstan --memory-limit=-1"
+    },
+    "config": {
+        "sort-packages": true
+    }
 }

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
     }
   ],
   "require": {
-    "php": "^7.3 || ^8.0",
+    "php": "^7.4 || ^8.0",
     "ext-SimpleXML": "*",
     "ext-fileinfo": "*",
     "ext-json": "*",

--- a/src/Factory/DecoratedResponseFactory.php
+++ b/src/Factory/DecoratedResponseFactory.php
@@ -17,15 +17,9 @@ use Slim\Http\Response;
 
 class DecoratedResponseFactory implements ResponseFactoryInterface
 {
-    /**
-     * @var ResponseFactoryInterface
-     */
-    protected $responseFactory;
+    protected ResponseFactoryInterface $responseFactory;
 
-    /**
-     * @var StreamFactoryInterface
-     */
-    protected $streamFactory;
+    protected StreamFactoryInterface $streamFactory;
 
     /**
      * @param ResponseFactoryInterface $responseFactory

--- a/src/Factory/DecoratedServerRequestFactory.php
+++ b/src/Factory/DecoratedServerRequestFactory.php
@@ -17,10 +17,7 @@ use Slim\Http\ServerRequest;
 
 class DecoratedServerRequestFactory implements ServerRequestFactoryInterface
 {
-    /**
-     * @var ServerRequestFactoryInterface
-     */
-    protected $serverRequestFactory;
+    protected ServerRequestFactoryInterface $serverRequestFactory;
 
     /**
      * @param ServerRequestFactoryInterface $serverRequestFactory

--- a/src/Factory/DecoratedUriFactory.php
+++ b/src/Factory/DecoratedUriFactory.php
@@ -16,10 +16,7 @@ use Slim\Http\Uri;
 
 class DecoratedUriFactory implements UriFactoryInterface
 {
-    /**
-     * @var UriFactoryInterface
-     */
-    protected $uriFactory;
+    protected UriFactoryInterface $uriFactory;
 
     /**
      * @param UriFactoryInterface $uriFactory

--- a/src/Response.php
+++ b/src/Response.php
@@ -36,15 +36,9 @@ use const JSON_ERROR_NONE;
 
 class Response implements ResponseInterface
 {
-    /**
-     * @var ResponseInterface
-     */
-    protected $response;
+    protected ResponseInterface $response;
 
-    /**
-     * @var StreamFactoryInterface
-     */
-    protected $streamFactory;
+    protected StreamFactoryInterface $streamFactory;
 
     /**
      * EOL characters used for HTTP response.

--- a/src/ServerRequest.php
+++ b/src/ServerRequest.php
@@ -36,15 +36,9 @@ use const LIBXML_VERSION;
 
 class ServerRequest implements ServerRequestInterface
 {
-    /**
-     * @var ServerRequestInterface
-     */
-    protected $serverRequest;
+    protected ServerRequestInterface $serverRequest;
 
-    /**
-     * @var array
-     */
-    protected $bodyParsers;
+    protected array $bodyParsers;
 
     /**
      * @param ServerRequestInterface $serverRequest

--- a/src/Uri.php
+++ b/src/Uri.php
@@ -14,10 +14,7 @@ use Psr\Http\Message\UriInterface;
 
 class Uri implements UriInterface
 {
-    /**
-     * @var UriInterface
-     */
-    protected $uri;
+    protected UriInterface $uri;
 
     /**
      * @param UriInterface $uri

--- a/tests/Psr7Integration/Laminas/UriTest.php
+++ b/tests/Psr7Integration/Laminas/UriTest.php
@@ -22,6 +22,11 @@ use function defined;
 
 class UriTest extends UriIntegrationTest
 {
+    // https://datatracker.ietf.org/doc/html/rfc3986#section-3.3
+    protected $skippedTests = [
+        'testPathWithMultipleSlashes' => 'laminas-diactoros does not respect RFC3986.',
+    ];
+
     public static function setUpBeforeClass(): void
     {
         if (!defined('URI_FACTORY')) {


### PR DESCRIPTION
This PR;
- drops support for PHP 7.3,
- upgrades GitHub Actions dependencies,
- temporarily fixes the tests until [this issue](https://github.com/laminas/laminas-diactoros/issues/74) is resolved by disabling the `testPathWithMultipleSlashes` integration test for [`laminas-diactoros`](https://github.com/laminas/laminas-diactoros).